### PR TITLE
add aarch64 support

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -685,7 +685,7 @@ bitflags! {
         const CONTEXT_ALPHA = 0x20000;
         const CONTEXT_AMD64 = 0x100000;
         const CONTEXT_ARM = 0x40000000;
-        const CONTEXT_ARM64 = 0x80000000;
+        const CONTEXT_ARM64 = 0x400000;
         const CONTEXT_MIPS = 0x40000;
         const CONTEXT_MIPS64 = 0x80000;
         const CONTEXT_PPC = 0x20000000;
@@ -856,11 +856,15 @@ pub struct FLOATING_SAVE_AREA_ARM64 {
 /// in WinNT.h.
 #[derive(Clone, Pread, SizeWith)]
 pub struct CONTEXT_ARM64 {
-    pub context_flags: u64,
+    pub context_flags: u32,
+    pub cpsr: u32,
     pub iregs: [u64; 32],
     pub pc: u64,
-    pub cpsr: u32,
     pub float_save: FLOATING_SAVE_AREA_ARM64,
+    pub bcr: [u32; 8],
+    pub bvr: [u64; 8],
+    pub wcr: [u32; 2],
+    pub wvr: [u64; 2],
 }
 
 /// Offsets into `CONTEXT_ARM64.iregs` for registers with a dedicated or conventional purpose

--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -857,7 +857,8 @@ pub struct FLOATING_SAVE_AREA_ARM64 {
 #[derive(Clone, Pread, SizeWith)]
 pub struct CONTEXT_ARM64 {
     pub context_flags: u64,
-    pub iregs: [u64; 33],
+    pub iregs: [u64; 32],
+    pub pc: u64,
     pub cpsr: u32,
     pub float_save: FLOATING_SAVE_AREA_ARM64,
 }

--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -831,7 +831,7 @@ pub struct CONTEXT_ARM {
     pub float_save: FLOATING_SAVE_AREA_ARM,
 }
 
-/// Offsets into `CONTEXT_ARM.iregs` for registers with a dediated or conventional purpose
+/// Offsets into `CONTEXT_ARM.iregs` for registers with a dedicated or conventional purpose
 #[repr(usize)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum ArmRegisterNumbers {
@@ -862,7 +862,7 @@ pub struct CONTEXT_ARM64 {
     pub float_save: FLOATING_SAVE_AREA_ARM64,
 }
 
-/// Offsets into `CONTEXT_ARM64.iregs` for registers with a dediated or conventional purpose
+/// Offsets into `CONTEXT_ARM64.iregs` for registers with a dedicated or conventional purpose
 #[repr(usize)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Arm64RegisterNumbers {
@@ -901,7 +901,7 @@ pub struct CONTEXT_MIPS {
     pub float_save: FLOATING_SAVE_AREA_MIPS,
 }
 
-/// Offsets into `CONTEXT_MIPS.iregs` for registers with a dediated or conventional purpose
+/// Offsets into `CONTEXT_MIPS.iregs` for registers with a dedicated or conventional purpose
 #[repr(usize)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum MipsRegisterNumbers {
@@ -956,7 +956,7 @@ pub struct CONTEXT_PPC {
     pub vector_save: VECTOR_SAVE_AREA_PPC,
 }
 
-/// Offsets into `CONTEXT_PPC.gpr` for registers with a dediated or conventional purpose
+/// Offsets into `CONTEXT_PPC.gpr` for registers with a dedicated or conventional purpose
 #[repr(usize)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum PpcRegisterNumbers {
@@ -981,7 +981,7 @@ pub struct CONTEXT_PPC64 {
     pub vector_save: VECTOR_SAVE_AREA_PPC,
 }
 
-/// Offsets into `CONTEXT_PPC64.gpr` for registers with a dediated or conventional purpose
+/// Offsets into `CONTEXT_PPC64.gpr` for registers with a dedicated or conventional purpose
 #[repr(usize)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Ppc64RegisterNumbers {
@@ -1013,7 +1013,7 @@ pub struct CONTEXT_SPARC {
     pub float_save: FLOATING_SAVE_AREA_SPARC,
 }
 
-/// Offsets into `CONTEXT_SPARC.g_r` for registers with a dediated or conventional purpose
+/// Offsets into `CONTEXT_SPARC.g_r` for registers with a dedicated or conventional purpose
 #[repr(usize)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum SparcRegisterNumbers {

--- a/src/context.rs
+++ b/src/context.rs
@@ -106,6 +106,51 @@ impl CPUContext for md::CONTEXT_AMD64 {
     }
 }
 
+impl CPUContext for md::CONTEXT_ARM64 {
+    type Register = u64;
+
+    fn get_register_always(&self, reg: &str) -> u64 {
+        match reg {
+            "x0" => self.iregs[0],
+            "x1" => self.iregs[1],
+            "x2" => self.iregs[2],
+            "x3" => self.iregs[3],
+            "x4" => self.iregs[4],
+            "x5" => self.iregs[5],
+            "x6" => self.iregs[6],
+            "x7" => self.iregs[7],
+            "x8" => self.iregs[8],
+            "x9" => self.iregs[9],
+            "x10" => self.iregs[10],
+            "x11" => self.iregs[11],
+            "x12" => self.iregs[12],
+            "x13" => self.iregs[13],
+            "x14" => self.iregs[14],
+            "x15" => self.iregs[15],
+            "x16" => self.iregs[16],
+            "x17" => self.iregs[17],
+            "x18" => self.iregs[18],
+            "x19" => self.iregs[19],
+            "x20" => self.iregs[20],
+            "x21" => self.iregs[21],
+            "x22" => self.iregs[22],
+            "x23" => self.iregs[23],
+            "x24" => self.iregs[24],
+            "x25" => self.iregs[25],
+            "x26" => self.iregs[26],
+            "x27" => self.iregs[27],
+            "x28" => self.iregs[28],
+            "x29" => self.iregs[29],
+            "x30" => self.iregs[30],
+            "x31" => self.iregs[31],
+            "pc" => self.pc,
+            "fp" => self.iregs[md::Arm64RegisterNumbers::FramePointer as usize],
+            "sp" => self.iregs[md::Arm64RegisterNumbers::StackPointer as usize],
+            _ => unreachable!("Invalid aarch64 register!"),
+        }
+    }
+}
+
 /// Information about which registers are valid in a `MinidumpContext`.
 #[derive(Clone, Debug, PartialEq)]
 pub enum MinidumpContextValidity {
@@ -276,7 +321,7 @@ impl MinidumpContext {
         match self.raw {
             MinidumpRawContext::AMD64(ref ctx) => ctx.format_register(reg),
             MinidumpRawContext::ARM(_) => unimplemented!(),
-            MinidumpRawContext::ARM64(_) => unimplemented!(),
+            MinidumpRawContext::ARM64(ref ctx) => ctx.format_register(reg),
             MinidumpRawContext::PPC(_) => unimplemented!(),
             MinidumpRawContext::PPC64(_) => unimplemented!(),
             MinidumpRawContext::SPARC(_) => unimplemented!(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -238,8 +238,7 @@ impl MinidumpContext {
             MinidumpRawContext::AMD64(ref ctx) => ctx.rip,
             MinidumpRawContext::ARM(ref ctx) =>
                 ctx.iregs[md::ArmRegisterNumbers::ProgramCounter as usize] as u64,
-            MinidumpRawContext::ARM64(ref ctx) =>
-                ctx.iregs[md::Arm64RegisterNumbers::ProgramCounter as usize],
+            MinidumpRawContext::ARM64(ref ctx) => ctx.pc,
             MinidumpRawContext::PPC(ref ctx) => ctx.srr0 as u64,
             MinidumpRawContext::PPC64(ref ctx) => ctx.srr0,
             MinidumpRawContext::SPARC(ref ctx) => ctx.pc,

--- a/src/context.rs
+++ b/src/context.rs
@@ -545,8 +545,29 @@ impl MinidumpContext {
                     try!(writeln!(f, "  float_save.extra[{:2}] = {:#x}", i, reg));
                 }
             }
-            MinidumpRawContext::ARM64(_) => {
-                unimplemented!();
+            MinidumpRawContext::ARM64(ref raw) => {
+                try!(write!(
+                    f,
+                    r#"CONTEXT_ARM64
+  context_flags        = {:#x}
+"#,
+                    raw.context_flags
+                ));
+                for (i, reg) in raw.iregs.iter().enumerate() {
+                    try!(writeln!(f, "  iregs[{:2}]            = {:#x}", i, reg));
+                }
+                try!(writeln!(f, "  pc                   = {:#x}", raw.pc));
+                try!(write!(
+                    f,
+                    r#"  cpsr                 = {:#x}
+  float_save.fpsr     = {:#x}
+  float_save.fpcr     = {:#x}
+"#,
+                    raw.cpsr, raw.float_save.fpsr, raw.float_save.fpcr
+                ));
+                for (i, reg) in raw.float_save.regs.iter().enumerate() {
+                    try!(writeln!(f, "  float_save.regs[{:2}] = {:#x}", i, reg));
+                }
             }
             MinidumpRawContext::MIPS(_) => {
                 unimplemented!();

--- a/src/context.rs
+++ b/src/context.rs
@@ -154,6 +154,14 @@ static X86_64_REGS: [&'static str; 17] = [
     "r14", "r15", "rip",
 ];
 
+/// General-purpose registers for aarch64.
+static ARM64_REGS: [&'static str; 33] = [
+    "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
+    "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15",
+    "x16", "x17", "x18", "x19", "x20", "x21", "x22", "x23",
+    "x24", "x25", "x26", "x27", "x28", "x29", "x30", "x31",
+    "pc",
+];
 //======================================================
 // Implementations
 
@@ -281,7 +289,7 @@ impl MinidumpContext {
         match self.raw {
             MinidumpRawContext::AMD64(_) => &X86_64_REGS[..],
             MinidumpRawContext::ARM(_) => unimplemented!(),
-            MinidumpRawContext::ARM64(_) => unimplemented!(),
+            MinidumpRawContext::ARM64(_) => &ARM64_REGS[..],
             MinidumpRawContext::PPC(_) => unimplemented!(),
             MinidumpRawContext::PPC64(_) => unimplemented!(),
             MinidumpRawContext::SPARC(_) => unimplemented!(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -187,15 +187,8 @@ impl MinidumpContext {
             } else {
                 return Ok(MinidumpContext::from_raw(MinidumpRawContext::PPC64(ctx)));
             }
-        } else if bytes.len() == mem::size_of::<md::CONTEXT_ARM64>() {
-            let ctx: md::CONTEXT_ARM64 = bytes.gread_with(&mut offset, endian)
-                .or(Err(ContextError::ReadFailure))?;
-            if ContextFlagsCpu::from_flags(ctx.context_flags as u32) != ContextFlagsCpu::CONTEXT_ARM64 {
-                return Err(ContextError::ReadFailure);
-            } else {
-                return Ok(MinidumpContext::from_raw(MinidumpRawContext::ARM64(ctx)));
-            }
         }
+        // TODO there's an "old" ARM64 implementation we could support here.
 
         // For everything else, read the flags and determine context
         // type from that.
@@ -228,6 +221,11 @@ impl MinidumpContext {
                 let ctx: md::CONTEXT_MIPS = bytes.gread_with(&mut offset, endian)
                     .or(Err(ContextError::ReadFailure))?;
                 Ok(MinidumpContext::from_raw(MinidumpRawContext::MIPS(ctx)))
+            }
+            ContextFlagsCpu::CONTEXT_ARM64 => {
+                let ctx: md::CONTEXT_ARM64 = bytes.gread_with(&mut offset, endian)
+                    .or(Err(ContextError::ReadFailure))?;
+                Ok(MinidumpContext::from_raw(MinidumpRawContext::ARM64(ctx)))
             }
             _ => Err(ContextError::UnknownCPUContext),
         }


### PR DESCRIPTION
This series gets me to the point where I can `minidump_stackwalk` and have at least the crashing thread line up with what crash-stats tells me.  I have an in-progress frame pointer unwind for aarch64, but that's not lining up with what crash-stats says, so we'll leave that bit for later.