### PR TITLE
change get-minidump-instructions to disassemble from crashing ip

### DIFF
--- a/minidump-tools/src/lib.rs
+++ b/minidump-tools/src/lib.rs
@@ -230,8 +230,8 @@ pub fn get_minidump_instructions() -> Result<(), Error> {
     println!("Faulting instruction pointer: {:#x}", ip);
     info!("Disassembling {} bytes starting at {:#x} of arch {:?}",
           memory.bytes.len(), memory.base_address, arch);
-    disasm::disasm_bytes(&memory.bytes,
-                         memory.base_address,
+    disasm::disasm_bytes(&memory.bytes[ip as usize - memory.base_address as usize..],
+                         ip,
                          arch,
                          color.unwrap_or(Color::Auto),
                          Some(ip),


### PR DESCRIPTION
The current implementation disassembles the entire memory region
containing the crashing ip.  But the entire region might not be
disassemblable (sp?): the region might start in the middle of a variable
length instruction or might contain just plain garbage in the case of
fixed width instructions.  And the underlying disassembler seems to give
up entirely in the case of stuff it can't disassemble, rather than
trying to move on.

Instead, let's start disassembling from the byte indicated by the
crashing ip.  This will at least produce reasonable output until we can
change the underlying disassembler or correctly call into the
disassembler to make it continue in the presence of garbage.