### PR TITLE
fix `dyn Trait` warnings

### DIFF
--- a/breakpad-symbols/src/sym_file/mod.rs
+++ b/breakpad-symbols/src/sym_file/mod.rs
@@ -23,7 +23,7 @@ impl SymbolFile {
     }
 
     /// Fill in as much source information for `frame` as possible.
-    pub fn fill_symbol(&self, module: &Module, frame: &mut FrameSymbolizer) {
+    pub fn fill_symbol(&self, module: &dyn Module, frame: &mut dyn FrameSymbolizer) {
         // Look for a FUNC covering the address first.
         if frame.get_instruction() < module.base_address() {
             return;

--- a/minidump-processor/src/dwarf_symbolizer.rs
+++ b/minidump-processor/src/dwarf_symbolizer.rs
@@ -37,7 +37,7 @@ impl DwarfSymbolizer {
 }
 
 impl SymbolProvider for DwarfSymbolizer {
-    fn fill_symbol(&self, module: &Module, frame: &mut FrameSymbolizer) {
+    fn fill_symbol(&self, module: &dyn Module, frame: &mut dyn FrameSymbolizer) {
         let path = module.code_file();
         let k = path.as_ref();
         if !self.known_modules.borrow().contains_key(k) {

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -11,18 +11,18 @@ use std::ops::Deref;
 use system_info::SystemInfo;
 
 pub trait SymbolProvider {
-    fn fill_symbol(&self, module: &Module, frame: &mut FrameSymbolizer);
+    fn fill_symbol(&self, module: &dyn Module, frame: &mut dyn FrameSymbolizer);
 }
 
 impl SymbolProvider for Symbolizer {
-    fn fill_symbol(&self, module: &Module, frame: &mut FrameSymbolizer) {
+    fn fill_symbol(&self, module: &dyn Module, frame: &mut dyn FrameSymbolizer) {
         self.fill_symbol(module, frame);
     }
 }
 
 #[derive(Default)]
 pub struct MultiSymbolProvider {
-    providers: Vec<Box<SymbolProvider>>,
+    providers: Vec<Box<dyn SymbolProvider>>,
 }
 
 impl MultiSymbolProvider {
@@ -30,13 +30,13 @@ impl MultiSymbolProvider {
         Default::default()
     }
 
-    pub fn add(&mut self, provider: Box<SymbolProvider>) {
+    pub fn add(&mut self, provider: Box<dyn SymbolProvider>) {
         self.providers.push(provider);
     }
 }
 
 impl SymbolProvider for MultiSymbolProvider {
-    fn fill_symbol(&self, module: &Module, frame: &mut FrameSymbolizer) {
+    fn fill_symbol(&self, module: &dyn Module, frame: &mut dyn FrameSymbolizer) {
         for p in self.providers.iter() {
             p.fill_symbol(module, frame);
         }

--- a/minidump-tools/src/lib.rs
+++ b/minidump-tools/src/lib.rs
@@ -117,7 +117,7 @@ fn fetch_url_to_path(client: &Client, url: &str, path: &Path) -> Result<(), Erro
     Ok(())
 }
 
-fn parse_vcs_info(filename: &str) -> Result<Box<VCSFile>, Error> {
+fn parse_vcs_info(filename: &str) -> Result<Box<dyn VCSFile>, Error> {
     let mut bits = filename.split(':');
     Ok(match (bits.next(), bits.next(), bits.next(), bits.next()) {
         (Some("hg"), Some(repo), Some(path), Some(rev)) if repo.starts_with("hg.mozilla.org/") => {

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -647,7 +647,7 @@ fn read_stream_list<'a, T>(offset: &mut usize, bytes: &'a [u8], endian: scroll::
 
 /// An iterator over `MinidumpModule`s.
 pub struct Modules<'a> {
-    iter: Box<Iterator<Item = &'a MinidumpModule> + 'a>,
+    iter: Box<dyn Iterator<Item = &'a MinidumpModule> + 'a>,
 }
 
 impl<'a> Iterator for Modules<'a> {
@@ -818,7 +818,7 @@ Memory
 pub struct MemoryRegions<'b, 'a>
     where 'a: 'b
 {
-    iter: Box<Iterator<Item = &'b MinidumpMemory<'a>> + 'b>,
+    iter: Box<dyn Iterator<Item = &'b MinidumpMemory<'a>> + 'b>,
 }
 
 impl<'b, 'a> Iterator for MemoryRegions<'b, 'a>


### PR DESCRIPTION
There are still a bunch of warnings about doc comments and macros, but these warnings, at least, were easy to fix.