### PR TITLE
Re-export scroll::Endian

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ extern crate scroll;
 #[cfg(test)]
 extern crate test_assembler;
 
+pub use scroll::Endian;
+
 mod context;
 mod iostuff;
 mod minidump;
@@ -40,6 +42,6 @@ pub mod synth_minidump;
 pub mod system_info;
 
 pub use iostuff::Readable;
+pub use minidump::*;
 pub use minidump_common::format;
 pub use minidump_common::traits::Module;
-pub use minidump::*;


### PR DESCRIPTION
This is a public field on the Minidump struct, but the API currently
forces you to explicitly pull in scroll to use it.  It seems
reasonable for the crate to export the types which which is uses in
public APIs.