### PR TITLE
Change multi_structs macro to compile on 1.47.0

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -1317,7 +1317,7 @@ macro_rules! multi_structs {
         multi_structs!($(#[$attr])* pub struct $name { $($prev)* $($cur)* } $($tail)*);
     };
     // Declare a single struct.
-    ($(#[$attr:meta])* pub struct $name:ident { $( pub $field:ident: $t:ty, )* } $($tail:tt)* ) => {
+    ($(#[$attr:meta])* pub struct $name:ident { $( pub $field:ident: $t:tt, )* } $($tail:tt)* ) => {
         $(#[$attr])*
         #[derive(Clone, Pread, SizeWith)]
         pub struct $name {


### PR DESCRIPTION
This is a quick workaround to fix compilation on Rust 1.47.0, which was released to the stable channel today. It seems that custom derives no longer resolve the syntax tree correctly when declared in a macro that uses `ty` matchers. When updated to `tt`, it works however.

I yet have to pin it down and then potentially report this upstream.

Fixes https://github.com/luser/rust-minidump/issues/100