### PR TITLE
Fixes for updated scroll dependency

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -338,9 +338,8 @@ pub struct CV_INFO_PDB20 {
 
 impl<'a> scroll::ctx::TryFromCtx<'a, Endian> for CV_INFO_PDB20 {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(src: &[u8], endian: Endian) -> Result<(Self, Self::Size), Self::Error> {
+    fn try_from_ctx(src: &[u8], endian: Endian) -> Result<(Self, usize), Self::Error> {
         let offset = &mut 0;
         Ok((CV_INFO_PDB20 {
             cv_signature: src.gread_with(offset, endian)?,
@@ -372,9 +371,8 @@ pub struct CV_INFO_PDB70 {
 
 impl<'a> scroll::ctx::TryFromCtx<'a, Endian> for CV_INFO_PDB70 {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(src: &[u8], endian: Endian) -> Result<(Self, Self::Size), Self::Error> {
+    fn try_from_ctx(src: &[u8], endian: Endian) -> Result<(Self, usize), Self::Error> {
         let offset = &mut 0;
         Ok((CV_INFO_PDB70 {
             cv_signature: src.gread_with(offset, endian)?,
@@ -420,9 +418,8 @@ pub struct CV_INFO_ELF {
 
 impl<'a> scroll::ctx::TryFromCtx<'a, Endian> for CV_INFO_ELF {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(src: &'a [u8], endian: Endian) -> Result<(Self, Self::Size), Self::Error> {
+    fn try_from_ctx(src: &'a [u8], endian: Endian) -> Result<(Self, usize), Self::Error> {
         let offset = &mut 0;
         Ok((CV_INFO_ELF {
             cv_signature: src.gread_with(offset, endian)?,

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -608,8 +608,8 @@ impl Module for MinidumpModule {
 }
 
 fn read_stream_list<'a, T>(offset: &mut usize, bytes: &'a [u8], endian: scroll::Endian) -> Result<Vec<T>, Error>
-    where T: TryFromCtx<'a, scroll::Endian, [u8], Error=scroll::Error, Size=usize>,
-          T: SizeWith<scroll::Endian, Units=usize>,
+    where T: TryFromCtx<'a, scroll::Endian, [u8], Error=scroll::Error>,
+          T: SizeWith<scroll::Endian>,
 {
     let u: u32 = bytes.gread_with(offset, endian).or(Err(Error::StreamReadFailure))?;
     let count = u as usize;
@@ -769,8 +769,8 @@ impl<'a> MinidumpMemory<'a> {
     /// Return `None` if the requested address range falls out of the bounds
     /// of this memory region.
     pub fn get_memory_at_address<T>(&self, addr: u64) -> Option<T>
-        where T: TryFromCtx<'a, scroll::Endian, [u8], Error=scroll::Error, Size=usize>,
-              T: SizeWith<scroll::Endian, Units=usize>,
+        where T: TryFromCtx<'a, scroll::Endian, [u8], Error=scroll::Error>,
+              T: SizeWith<scroll::Endian>,
     {
         let in_range = |a: u64| a >= self.base_address && a < (self.base_address + self.size);
         let size = <T>::size_with(&LE);


### PR DESCRIPTION
The new scroll dependency introduced in
https://github.com/luser/rust-minidump/pull/101 has slightly
simplified traits.  Adapt the code to work with these.