### PR TITLE
Fixes for new reqwest version

### DIFF
--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -17,7 +17,7 @@ minidump-common = { version = "0.2.0", path = "../minidump-common" }
 range-map = "0.1.5"
 nom = "~1.2.2"
 log = "0.4.1"
-reqwest = "0.10.8"
+reqwest = { version = "0.10.8", features = ["blocking"] }
 failure = "0.1.1"
 
 [dev-dependencies]

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -45,7 +45,8 @@ mod sym_file;
 
 use failure::Error;
 pub use minidump_common::traits::Module;
-use reqwest::{Client, Url};
+use reqwest::Url;
+use reqwest::blocking::Client;
 use std::borrow::Cow;
 use std::boxed::Box;
 use std::cell::RefCell;

--- a/minidump-tools/Cargo.toml
+++ b/minidump-tools/Cargo.toml
@@ -10,6 +10,6 @@ minidump = { version = "0.2.0", path = ".." }
 minidump-common = { version = "0.2.0", path = "../minidump-common" }
 structopt = { version = "0.2", default-features = false }
 disasm = { git = "https://github.com/luser/rust-disasm", rev = "274ff86cd5258e8e6534d93ad7a063105b7ecb99" }
-reqwest = "0.10.8"
+reqwest = { version = "0.10.8", features = ["blocking"] }
 log = "0.4.1"
 env_logger = "0.5.6"

--- a/minidump-tools/src/lib.rs
+++ b/minidump-tools/src/lib.rs
@@ -19,7 +19,7 @@ use minidump_common::traits::Module;
 use minidump::{Minidump, MinidumpException, MinidumpMemoryList, MinidumpModule, MinidumpModuleList,
                MinidumpSystemInfo};
 use minidump::system_info::Cpu;
-use reqwest::Client;
+use reqwest::blocking::Client;
 use std::env;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
https://github.com/luser/rust-minidump/pull/97 updated the reqwest
version which by default uses async code now.  Migrate to the blocking
client feature instead.