### PR TITLE
Enable all CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings
-  PWD: ${{ env.GITHUB_WORKSPACE }}
 
 jobs:
 
@@ -40,6 +39,8 @@ jobs:
             components: clippy
             override: true
       - uses: actions-rs/clippy-check@v1
+        env:
+          PWD: ${{ env.GITHUB_WORKSPACE }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --workspace --tests --examples
@@ -81,10 +82,14 @@ jobs:
         with:
           key: ${{ github.job }}
       - uses: actions-rs/cargo@v1
+        env:
+          PWD: ${{ env.GITHUB_WORKSPACE }}
         with:
           command: test
           args: --workspace
       - uses: actions-rs/cargo@v1
+        env:
+          PWD: ${{ env.GITHUB_WORKSPACE }}
         with:
           command: test
           args: --workspace --examples --bins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings
+  PWD: ${{ env.GITHUB_WORKSPACE }}
 
 jobs:
 
@@ -80,14 +81,10 @@ jobs:
         with:
           key: ${{ github.job }}
       - uses: actions-rs/cargo@v1
-        env:
-          PWD: ${{ env.GITHUB_WORKSPACE }}
         with:
           command: test
           args: --workspace
       - uses: actions-rs/cargo@v1
-        env:
-          PWD: ${{ env.GITHUB_WORKSPACE }}
         with:
           command: test
           args: --workspace --examples --bins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,8 @@ on:
   schedule:
     - cron: '11 7 * * 1,4'
 
-# env:
-#   RUSTFLAGS: -Dwarnings
-#   RUSTDOCFLAGS: -Dwarnings
+env:
+  RUSTFLAGS: -Dwarnings
 
 jobs:
 
@@ -29,23 +28,25 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  # clippy:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #           toolchain: stable
-  #           profile: minimal
-  #           components: clippy
-  #           override: true
-  #     - uses: actions-rs/clippy-check@v1
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         args: --workspace --tests --examples
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            profile: minimal
+            components: clippy
+            override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --workspace --tests --examples
 
   docs:
     runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,3 @@ members = [
         "minidump-processor",
         "minidump-tools",
 ]
-
-[replace]
-"scroll:0.9.0" = { git = "https://github.com/m4b/scroll", rev = "afbd4121c602363936b1c09b652f8ea04bb91eeb" }
-"scroll_derive:0.9.4" = { git = "https://github.com/m4b/scroll_derive", rev = "d8fe9d0a5a7ea21823ce9fd6206766ae81782e4a" }

--- a/breakpad-symbols/src/sym_file/mod.rs
+++ b/breakpad-symbols/src/sym_file/mod.rs
@@ -51,7 +51,7 @@ impl SymbolFile {
             }
         }
 
-        return None;
+        None
     }
 }
 

--- a/breakpad-symbols/src/sym_file/parser.rs
+++ b/breakpad-symbols/src/sym_file/parser.rs
@@ -31,14 +31,14 @@ named!(
     complete!(preceded!(many0!(char!('\r')), char!('\n')))
 );
 
-/// Match a hex string, parse it to a u64.
+// Match a hex string, parse it to a u64.
 named!(hex_str_u64<&[u8], u64>,
        map_res!(map_res!(hex_digit, str::from_utf8), |s| u64::from_str_radix(s, 16)));
 
-/// Match a decimal string, parse it to a u32.
+// Match a decimal string, parse it to a u32.
 named!(decimal_u32<&[u8], u32>, map_res!(map_res!(digit, str::from_utf8), FromStr::from_str));
 
-/// Matches a MODULE record.
+// Matches a MODULE record.
 named!(module_line<&[u8], ()>,
   chain!(
     tag!("MODULE") ~
@@ -58,7 +58,7 @@ named!(module_line<&[u8], ()>,
     || {}
 ));
 
-/// Matches an INFO record.
+// Matches an INFO record.
 named!(
     info_line,
     chain!(
@@ -70,7 +70,7 @@ named!(
     )
 );
 
-/// Matches a FILE record.
+// Matches a FILE record.
 named!(file_line<&[u8], (u32, &str)>,
   chain!(
     tag!("FILE") ~
@@ -82,7 +82,7 @@ named!(file_line<&[u8], (u32, &str)>,
       ||{ (id, filename) }
 ));
 
-/// Matches a PUBLIC record.
+// Matches a PUBLIC record.
 named!(public_line<&[u8], PublicSymbol>,
   chain!(
     tag!("PUBLIC") ~
@@ -103,7 +103,7 @@ named!(public_line<&[u8], PublicSymbol>,
       }
 ));
 
-/// Matches line data after a FUNC record.
+// Matches line data after a FUNC record.
 named!(func_line_data<&[u8], SourceLine>,
   chain!(
     address: hex_str_u64 ~
@@ -124,7 +124,7 @@ named!(func_line_data<&[u8], SourceLine>,
       }
 ));
 
-/// Matches a FUNC record and any following line records.
+// Matches a FUNC record and any following line records.
 named!(func_lines<&[u8], Function>,
 chain!(
   tag!("FUNC") ~
@@ -160,7 +160,7 @@ chain!(
     }
     ));
 
-/// Matches a STACK WIN record.
+// Matches a STACK WIN record.
 named!(stack_win_line<&[u8], WinFrameType>,
   chain!(
     tag!("STACK WIN") ~
@@ -213,7 +213,7 @@ named!(stack_win_line<&[u8], WinFrameType>,
       }
 ));
 
-/// Matches a STACK CFI record.
+// Matches a STACK CFI record.
 named!(stack_cfi<&[u8], CFIRules>,
 chain!(
     tag!("STACK CFI") ~
@@ -230,7 +230,7 @@ chain!(
     }
     ));
 
-/// Matches a STACK CFI INIT record.
+// Matches a STACK CFI INIT record.
 named!(stack_cfi_init<&[u8], (CFIRules, u32)>,
   chain!(
     tag!("STACK CFI INIT") ~
@@ -250,7 +250,7 @@ named!(stack_cfi_init<&[u8], (CFIRules, u32)>,
       }
 ));
 
-/// Match a STACK CFI INIT record followed by zero or more STACK CFI records.
+// Match a STACK CFI INIT record followed by zero or more STACK CFI records.
 named!(stack_cfi_lines<&[u8], StackInfoCFI>,
   chain!(
     init: stack_cfi_init ~
@@ -266,7 +266,7 @@ named!(stack_cfi_lines<&[u8], StackInfoCFI>,
       }
 ));
 
-/// Parse any of the line data that can occur in the body of a symbol file.
+// Parse any of the line data that can occur in the body of a symbol file.
 named!(line<&[u8], Line>,
   alt!(
     info_line => { |_| Line::Info } |
@@ -277,7 +277,7 @@ named!(line<&[u8], Line>,
     stack_cfi_lines => { |s| Line::StackCFI(s) }
 ));
 
-/// Return a `SymbolFile` given a vec of `Line` data.
+// Return a `SymbolFile` given a vec of `Line` data.
 fn symbol_file_from_lines<'a>(lines: Vec<Line<'a>>) -> SymbolFile {
     let mut files = HashMap::new();
     let mut publics = vec![];
@@ -347,7 +347,7 @@ fn symbol_file_from_lines<'a>(lines: Vec<Line<'a>>) -> SymbolFile {
     }
 }
 
-/// Matches an entire symbol file.
+// Matches an entire symbol file.
 named!(symbol_file<&[u8], SymbolFile>,
   chain!(
     module_line? ~

--- a/breakpad-symbols/src/sym_file/parser.rs
+++ b/breakpad-symbols/src/sym_file/parser.rs
@@ -96,8 +96,8 @@ named!(public_line<&[u8], PublicSymbol>,
     my_eol ,
       || {
           PublicSymbol {
-              address: address,
-              parameter_size: parameter_size,
+              address,
+              parameter_size,
               name: name.to_string()
           }
       }
@@ -116,10 +116,10 @@ named!(func_line_data<&[u8], SourceLine>,
     my_eol ,
       || {
           SourceLine {
-              address: address,
-              size: size,
+              address,
+              size,
               file: filenum,
-              line: line,
+              line,
           }
       }
 ));
@@ -141,9 +141,9 @@ chain!(
   lines: many0!(func_line_data) ,
     || {
         Function {
-            address: address,
-            size: size,
-            parameter_size: parameter_size,
+            address,
+            size,
+            parameter_size,
             name: name.to_string(),
             lines: lines.into_iter()
                 .filter_map(|l| {
@@ -195,14 +195,14 @@ named!(stack_win_line<&[u8], WinFrameType>,
               WinStackThing::AllocatesBasePointer(rest == "1")
           };
           let info = StackInfoWin {
-              address: address,
+              address,
               size: code_size,
-              prologue_size: prologue_size,
-              epilogue_size: epilogue_size,
-              parameter_size: parameter_size,
-              saved_register_size: saved_register_size,
-              local_size: local_size,
-              max_stack_size: max_stack_size,
+              prologue_size,
+              epilogue_size,
+              parameter_size,
+              saved_register_size,
+              local_size,
+              max_stack_size,
               program_string_or_base_pointer,
           };
           match ty {
@@ -224,7 +224,7 @@ chain!(
         my_eol ,
     || {
         CFIRules {
-            address: address,
+            address,
             rules: rules.to_string(),
         }
     }
@@ -243,7 +243,7 @@ named!(stack_cfi_init<&[u8], (CFIRules, u32)>,
     my_eol ,
       || {
           (CFIRules {
-              address: address,
+              address,
               rules: rules.to_string(),
           },
            size)
@@ -260,8 +260,8 @@ named!(stack_cfi_lines<&[u8], StackInfoCFI>,
           add_rules.sort();
           StackInfoCFI {
               init: init_rules,
-              size: size,
-              add_rules: add_rules,
+              size,
+              add_rules,
           }
       }
 ));
@@ -278,7 +278,7 @@ named!(line<&[u8], Line>,
 ));
 
 // Return a `SymbolFile` given a vec of `Line` data.
-fn symbol_file_from_lines<'a>(lines: Vec<Line<'a>>) -> SymbolFile {
+fn symbol_file_from_lines(lines: Vec<Line<'_>>) -> SymbolFile {
     let mut files = HashMap::new();
     let mut publics = vec![];
     let mut funcs = vec![];
@@ -326,8 +326,8 @@ fn symbol_file_from_lines<'a>(lines: Vec<Line<'a>>) -> SymbolFile {
     }
     publics.sort();
     SymbolFile {
-        files: files,
-        publics: publics,
+        files,
+        publics,
         functions: funcs
             .into_iter()
             .map(|f| (f.memory_range(), f))
@@ -550,7 +550,7 @@ fn test_func_lines_and_lines() {
             ]
         );
     } else {
-        assert!(false, "Failed to parse!");
+        panic!("Failed to parse!");
     }
 }
 
@@ -564,7 +564,7 @@ fn test_func_with_m() {
     if let Done(rest, _) = func_lines(data) {
         assert_eq!(rest, &b""[..]);
     } else {
-        assert!(false, "Failed to parse!");
+        panic!("Failed to parse!");
     }
 }
 
@@ -591,12 +591,12 @@ fn test_stack_win_line_program_string() {
             );
         }
         Error(e) => {
-            assert!(false, format!("Parse error: {:?}", e));
+            panic!(format!("Parse error: {:?}", e));
         }
         Incomplete(_) => {
-            assert!(false, "Incomplete parse!");
+            panic!("Incomplete parse!");
         }
-        _ => assert!(false, "Something bad happened"),
+        _ => panic!("Something bad happened"),
     }
 }
 
@@ -620,12 +620,12 @@ fn test_stack_win_line_frame_data() {
             );
         }
         Error(e) => {
-            assert!(false, format!("Parse error: {:?}", e));
+            panic!(format!("Parse error: {:?}", e));
         }
         Incomplete(_) => {
-            assert!(false, "Incomplete parse!");
+            panic!("Incomplete parse!");
         }
-        _ => assert!(false, "Something bad happened"),
+        _ => panic!("Something bad happened"),
     }
 }
 

--- a/examples/dumpmodules.rs
+++ b/examples/dumpmodules.rs
@@ -12,7 +12,7 @@ extern crate minidump_common;
 use minidump::*;
 use minidump_common::traits::Module;
 
-const USAGE: &'static str = "Usage: dumpmodules [-v] <minidump>
+const USAGE: &str = "Usage: dumpmodules [-v] <minidump>
 Print full paths of modules from a minidump that were loaded in the crashed
 process.
 
@@ -37,7 +37,7 @@ fn print_minidump_modules<T: AsRef<Path>>(path: T, verbose: Verbose) {
                             print!("{}", debug_id);
                         }
                     }
-                    println!("");
+                    println!();
                 }
             }
         }
@@ -55,7 +55,7 @@ fn main() {
     for arg in env::args_os().skip(1) {
         if arg == OsStr::new("-v") {
             verbose = Verbose::Yes;
-        } else if arg.to_str().map(|s| s.starts_with("-")).unwrap_or(false) {
+        } else if arg.to_str().map(|s| s.starts_with('-')).unwrap_or(false) {
             writeln!(&mut stderr, "Unknown argument {:?}", arg).unwrap();
             break;
         } else {

--- a/minidump-processor/src/bin/minidump_stackwalk.rs
+++ b/minidump-processor/src/bin/minidump_stackwalk.rs
@@ -15,17 +15,17 @@ use minidump::*;
 use minidump_processor::{DwarfSymbolizer, MultiSymbolProvider};
 use std::boxed::Box;
 
-const USAGE: &'static str = "usage: minidump_stackwalk <minidump-file> [symbol-path ...]";
+const USAGE: &str = "usage: minidump_stackwalk <minidump-file> [symbol-path ...]";
 
 fn print_minidump_process(path: &Path, symbol_paths: Vec<PathBuf>) {
     let mut stderr = std::io::stderr();
-    if let Ok(mut dump) = Minidump::read_path(path) {
+    if let Ok(dump) = Minidump::read_path(path) {
         let mut provider = MultiSymbolProvider::new();
         provider.add(Box::new(Symbolizer::new(SimpleSymbolSupplier::new(
             symbol_paths,
         ))));
         provider.add(Box::new(DwarfSymbolizer::new()));
-        match minidump_processor::process_minidump(&mut dump, &provider) {
+        match minidump_processor::process_minidump(&dump, &provider) {
             Ok(state) => {
                 let mut stdout = std::io::stdout();
                 state.print(&mut stdout).unwrap();

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -183,8 +183,8 @@ impl StackFrame {
             source_file_name: None,
             source_line: None,
             source_line_base: None,
-            trust: trust,
-            context: context,
+            trust,
+            context,
         }
     }
 
@@ -251,7 +251,7 @@ impl CallStack {
     /// Create a `CallStack` with `info` and no frames.
     pub fn with_info(info: CallStackInfo) -> CallStack {
         CallStack {
-            info: info,
+            info,
             frames: vec![],
         }
     }
@@ -261,7 +261,7 @@ impl CallStack {
     /// This is very verbose, it implements the output format used by
     /// minidump_stackwalk.
     pub fn print<T: Write>(&self, f: &mut T) -> io::Result<()> {
-        if self.frames.len() == 0 {
+        if self.frames.is_empty() {
             writeln!(f, "<no frames>")?;
         }
         for (i, frame) in self.frames.iter().enumerate() {
@@ -298,7 +298,7 @@ impl CallStack {
             } else {
                 writeln!(f, "{:#x}", addr)?;
             }
-            writeln!(f, "")?;
+            writeln!(f)?;
             print_registers(f, &frame.context)?;
             writeln!(f, "    Found by: {}", frame.trust.description())?;
         }
@@ -341,7 +341,7 @@ impl ProcessState {
                 ""
             }
         )?;
-        writeln!(f, "")?;
+        writeln!(f)?;
 
         if let (&Some(ref reason), &Some(ref address)) = (&self.crash_reason, &self.crash_address) {
             write!(
@@ -363,7 +363,7 @@ Crash address: {:#x}
         } else {
             writeln!(f, "Process uptime: not available")?;
         }
-        writeln!(f, "")?;
+        writeln!(f)?;
 
         if let Some(requesting_thread) = self.requesting_thread {
             writeln!(
@@ -377,7 +377,7 @@ Crash address: {:#x}
                 }
             )?;
             self.threads[requesting_thread].print(f)?;
-            writeln!(f, "")?;
+            writeln!(f)?;
         }
         for (i, stack) in self.threads.iter().enumerate() {
             if eq_some(self.requesting_thread, i) {
@@ -396,10 +396,7 @@ Crash address: {:#x}
 Loaded modules:
 "
         )?;
-        let main_address = self
-            .modules
-            .main_module()
-            .and_then(|m| Some(m.base_address()));
+        let main_address = self.modules.main_module().map(|m| m.base_address());
         for module in self.modules.by_addr() {
             // TODO: missing symbols, corrupt symbols
             write!(
@@ -413,7 +410,7 @@ Loaded modules:
             if eq_some(main_address, module.base_address()) {
                 write!(f, "  (main)")?;
             }
-            writeln!(f, "")?;
+            writeln!(f)?;
         }
         Ok(())
     }

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -139,7 +139,7 @@ where
     // Get assertion
     let assertion = None;
     let modules = if let Ok(module_list) = dump.get_stream::<MinidumpModuleList>() {
-        module_list.clone()
+        module_list
     } else {
         // Just give an empty list, simplifies things.
         MinidumpModuleList::new()
@@ -159,7 +159,7 @@ where
             && requesting_thread_id.unwrap() == thread.raw.thread_id
         {
             requesting_thread = Some(i);
-            exception_context.or(thread.context.as_ref())
+            exception_context.or_else(|| thread.context.as_ref())
         } else {
             thread.context.as_ref()
         };
@@ -169,13 +169,13 @@ where
     // if exploitability enabled, run exploitability analysis
     Ok(ProcessState {
         time: Utc.timestamp(dump.header.time_date_stamp as i64, 0),
-        process_create_time: process_create_time,
-        crash_reason: crash_reason,
-        crash_address: crash_address,
-        assertion: assertion,
-        requesting_thread: requesting_thread,
-        system_info: system_info,
-        threads: threads,
-        modules: modules,
+        process_create_time,
+        crash_reason,
+        crash_address,
+        assertion,
+        requesting_thread,
+        system_info,
+        threads,
+        modules,
     })
 }

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -41,7 +41,7 @@ fn fill_source_line_info<P>(
     P: SymbolProvider,
 {
     // Find the module whose address range covers this frame's instruction.
-    if let &Some(module) = &modules.module_at_address(frame.instruction) {
+    if let Some(module) = modules.module_at_address(frame.instruction) {
         // FIXME: this shouldn't need to clone, we should be able to use
         // the same lifetime as the module list that's passed in.
         frame.module = Some(module.clone());
@@ -62,7 +62,7 @@ where
     // no more.
     let mut frames = vec![];
     let mut info = CallStackInfo::Ok;
-    if let &Some(context) = maybe_context {
+    if let Some(context) = *maybe_context {
         let ctx = context.clone();
         let mut maybe_frame = Some(StackFrame::from_context(ctx, FrameTrust::Context));
         while let Some(mut frame) = maybe_frame {
@@ -74,10 +74,7 @@ where
     } else {
         info = CallStackInfo::MissingContext;
     }
-    CallStack {
-        frames: frames,
-        info: info,
-    }
+    CallStack { frames, info }
 }
 
 #[cfg(test)]

--- a/minidump-processor/src/stackwalker/x86.rs
+++ b/minidump-processor/src/stackwalker/x86.rs
@@ -12,9 +12,9 @@ fn get_caller_by_frame_pointer(
     valid: &MinidumpContextValidity,
     stack_memory: &MinidumpMemory,
 ) -> Option<StackFrame> {
-    match valid {
-        &MinidumpContextValidity::All => {}
-        &MinidumpContextValidity::Some(ref which) => {
+    match *valid {
+        MinidumpContextValidity::All => {}
+        MinidumpContextValidity::Some(ref which) => {
             if !which.contains("ebp") {
                 return None;
             }

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -39,7 +39,7 @@ impl TestFixture {
         let stack_memory = MinidumpMemory {
             desc: Default::default(),
             base_address: base,
-            size: size,
+            size,
             bytes: &stack,
         };
         walk_stack(

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -82,7 +82,7 @@ fn test_processor() {
         assert_eq!(raw.eip, 0x0040429e);
         assert_eq!(*valid, MinidumpContextValidity::All);
     } else {
-        assert!(false, "Wrong context type");
+        panic!("Wrong context type");
     }
 
     // Check thread 0, frame 3.
@@ -98,16 +98,16 @@ fn test_processor() {
     } = f3.context
     {
         assert_eq!(raw.eip, 0x7c816fd7);
-        match valid {
-            &MinidumpContextValidity::All => assert!(false, "Should not have all registers valid"),
-            &MinidumpContextValidity::Some(ref which) => {
+        match *valid {
+            MinidumpContextValidity::All => panic!("Should not have all registers valid"),
+            MinidumpContextValidity::Some(ref which) => {
                 assert!(which.contains("eip"));
                 assert!(which.contains("esp"));
                 assert!(which.contains("ebp"));
             }
         }
     } else {
-        assert!(false, "Wrong context type");
+        panic!("Wrong context type");
     }
 
     // The dump thread should have been skipped.
@@ -127,7 +127,7 @@ fn test_processor_symbols() {
     .unwrap();
     let f0 = &state.threads[0].frames[0];
     assert_eq!(
-        f0.function_name.as_ref().map(|s| s.as_str()),
+        f0.function_name.as_deref(),
         Some("`anonymous namespace'::CrashFunction")
     );
 }

--- a/minidump-tools/src/lib.rs
+++ b/minidump-tools/src/lib.rs
@@ -317,7 +317,7 @@ fn print_frame(module: &MinidumpModule, frame: SimpleFrame) {
     } else {
         print!(" + {:#x}", frame.instruction - module.base_address());
     }
-    println!("");
+    println!();
 }
 
 pub fn dump_minidump_stack() -> Result<(), Error> {

--- a/src/bin/minidump_dump.rs
+++ b/src/bin/minidump_dump.rs
@@ -11,7 +11,7 @@ extern crate minidump_common;
 
 use minidump::*;
 
-const USAGE: &'static str = "Usage: minidump_dump <minidump>";
+const USAGE: &str = "Usage: minidump_dump <minidump>";
 
 macro_rules! streams {
     ( $( $x:ident ),* ) => {

--- a/src/context.rs
+++ b/src/context.rs
@@ -235,18 +235,18 @@ pub enum ContextError {
 }
 
 /// General-purpose registers for x86.
-static X86_REGS: [&'static str; 10] = [
+static X86_REGS: [&str; 10] = [
     "eip", "esp", "ebp", "ebx", "esi", "edi", "eax", "ecx", "edx", "efl",
 ];
 
 /// General-purpose registers for x86-64.
-static X86_64_REGS: [&'static str; 17] = [
+static X86_64_REGS: [&str; 17] = [
     "rax", "rdx", "rcx", "rbx", "rsi", "rdi", "rbp", "rsp", "r8", "r9", "r10", "r11", "r12", "r13",
     "r14", "r15", "rip",
 ];
 
 /// General-purpose registers for aarch64.
-static ARM64_REGS: [&'static str; 33] = [
+static ARM64_REGS: [&str; 33] = [
     "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14",
     "x15", "x16", "x17", "x18", "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27",
     "x28", "x29", "x30", "x31", "pc",
@@ -258,7 +258,7 @@ impl MinidumpContext {
     /// Return a MinidumpContext given a `MinidumpRawContext`.
     pub fn from_raw(raw: MinidumpRawContext) -> MinidumpContext {
         MinidumpContext {
-            raw: raw,
+            raw,
             valid: MinidumpContextValidity::All,
         }
     }
@@ -463,7 +463,7 @@ impl MinidumpContext {
                     raw.float_save.register_area.len(),
                 )?;
                 write_bytes(f, &raw.float_save.register_area)?;
-                write!(f, "\n")?;
+                writeln!(f, "")?;
                 write!(
                     f,
                     r#"  float_save.cr0_npx_state     = {:#x}

--- a/src/context.rs
+++ b/src/context.rs
@@ -463,7 +463,7 @@ impl MinidumpContext {
                     raw.float_save.register_area.len(),
                 )?;
                 write_bytes(f, &raw.float_save.register_area)?;
-                writeln!(f, "")?;
+                writeln!(f)?;
                 write!(
                     f,
                     r#"  float_save.cr0_npx_state     = {:#x}

--- a/src/context.rs
+++ b/src/context.rs
@@ -39,7 +39,7 @@ pub trait CPUContext {
     /// if `valid` indicates that it has a valid value, otherwise return
     /// `None`.
     fn get_register(&self, reg: &str, valid: &MinidumpContextValidity) -> Option<Self::Register> {
-        if let &MinidumpContextValidity::Some(ref which) = valid {
+        if let MinidumpContextValidity::Some(ref which) = *valid {
             if !which.contains(reg) {
                 return None;
             }

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -1695,7 +1695,7 @@ mod test {
     fn read_synth_dump<'a>(dump: SynthMinidump) -> Result<Minidump<'a, Vec<u8>>, Error> {
         dump.finish()
             .ok_or(Error::FileNotFound)
-            .and_then(|bytes| Minidump::read(bytes))
+            .and_then(Minidump::read)
     }
 
     #[test]
@@ -1883,7 +1883,7 @@ mod test {
         assert_eq!(modules[4].code_file(), "module 5");
 
         // module_at_address should discard overlapping modules.
-        assert_eq!(module_list.by_addr().collect::<Vec<_>>().len(), 2);
+        assert_eq!(module_list.by_addr().count(), 2);
         assert_eq!(
             module_list
                 .module_at_address(0x100001000)
@@ -1965,7 +1965,7 @@ mod test {
         assert_eq!(regions[4].size, 0x1000);
 
         // memory_at_address should discard overlapping regions.
-        assert_eq!(memory_list.by_addr().collect::<Vec<_>>().len(), 2);
+        assert_eq!(memory_list.by_addr().count(), 2);
         let m1 = memory_list.memory_at_address(0x1a00).unwrap();
         assert_eq!(m1.base_address, 0x1000);
         assert_eq!(m1.size, 0x1000);
@@ -2110,7 +2110,7 @@ mod test {
                 assert_eq!(raw.eip, 0xabcd1234);
                 assert_eq!(raw.esp, 0x1010);
             }
-            _ => assert!(false, "Got unexpected raw context type!"),
+            _ => panic!("Got unexpected raw context type!"),
         }
         let stack = thread.stack.take().expect("Should have stack memory");
         assert_eq!(stack.base_address, 0x1000);
@@ -2141,7 +2141,7 @@ mod test {
                 assert_eq!(raw.rip, 0x1234abcd1234abcd);
                 assert_eq!(raw.rsp, 0x1000000010000000);
             }
-            _ => assert!(false, "Got unexpected raw context type!"),
+            _ => panic!("Got unexpected raw context type!"),
         }
         let stack = thread.stack.take().expect("Should have stack memory");
         assert_eq!(stack.base_address, 0x1000000010000000);

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -840,7 +840,7 @@ Memory
             self.desc.start_of_memory_range, self.desc.memory.data_size, self.desc.memory.rva,
         )?;
         self.print_contents(f)?;
-        write!(f, "\n")
+        writeln!(f, "")
     }
 
     /// Write the contents of this `MinidumpMemory` to `f` as a hex string.
@@ -849,7 +849,7 @@ Memory
         for byte in self.bytes.iter() {
             write!(f, "{:02x}", byte)?;
         }
-        write!(f, "\n")?;
+        writeln!(f, "")?;
         Ok(())
     }
 
@@ -1014,7 +1014,7 @@ impl<'a> MinidumpThread<'a> {
         } else {
             writeln!(f, "No stack")?;
         }
-        write!(f, "\n")?;
+        writeln!(f, "")?;
         Ok(())
     }
 }
@@ -1044,8 +1044,8 @@ impl<'a> MinidumpStream<'a> for MinidumpThreadList<'a> {
             });
         }
         Ok(MinidumpThreadList {
-            threads: threads,
-            thread_ids: thread_ids,
+            threads,
+            thread_ids,
         })
     }
 }
@@ -1073,7 +1073,7 @@ impl<'a> MinidumpThreadList<'a> {
         )?;
 
         for (i, thread) in self.threads.iter().enumerate() {
-            write!(f, "thread[{}]\n", i)?;
+            writeln!(f, "thread[{}]", i)?;
             thread.print(f)?;
         }
         Ok(())
@@ -1654,18 +1654,18 @@ MDRawDirectory
                 stream.location.rva
             )?;
         }
-        write!(f, "Streams:\n")?;
+        writeln!(f, "Streams:")?;
         streams.sort_by(|&(&a, &(_, _)), &(&b, &(_, _))| a.cmp(&b));
         for (_, &(i, ref stream)) in streams {
-            write!(
+            writeln!(
                 f,
-                "  stream type {:#x} ({}) at index {}\n",
+                "  stream type {:#x} ({}) at index {}",
                 stream.stream_type,
                 get_stream_name(stream.stream_type),
                 i
             )?;
         }
-        write!(f, "\n")?;
+        writeln!(f, "")?;
         Ok(())
     }
 }
@@ -1889,7 +1889,7 @@ mod test {
 
     #[test]
     fn test_memory_list() {
-        const CONTENTS: &'static [u8] = b"memory_contents";
+        const CONTENTS: &[u8] = b"memory_contents";
         let memory = Memory::with_section(
             Section::with_endian(Endian::Little).append_bytes(CONTENTS),
             0x309d68010bd21b2c,

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -840,7 +840,7 @@ Memory
             self.desc.start_of_memory_range, self.desc.memory.data_size, self.desc.memory.rva,
         )?;
         self.print_contents(f)?;
-        writeln!(f, "")
+        writeln!(f)
     }
 
     /// Write the contents of this `MinidumpMemory` to `f` as a hex string.
@@ -849,7 +849,7 @@ Memory
         for byte in self.bytes.iter() {
             write!(f, "{:02x}", byte)?;
         }
-        writeln!(f, "")?;
+        writeln!(f)?;
         Ok(())
     }
 
@@ -1014,7 +1014,7 @@ impl<'a> MinidumpThread<'a> {
         } else {
             writeln!(f, "No stack")?;
         }
-        writeln!(f, "")?;
+        writeln!(f)?;
         Ok(())
     }
 }
@@ -1255,7 +1255,7 @@ impl MinidumpMiscInfo {
             None => writeln!(f, "(invalid)")?,
         }
         // TODO: version 2-4 fields
-        writeln!(f, "")?;
+        writeln!(f)?;
         Ok(())
     }
 }
@@ -1424,7 +1424,7 @@ impl MinidumpException {
             self.raw.thread_context.data_size, self.raw.thread_context.rva
         )?;
         if let Some(ref context) = self.context {
-            writeln!(f, "")?;
+            writeln!(f)?;
             context.print(f)?;
         } else {
             write!(
@@ -1665,7 +1665,7 @@ MDRawDirectory
                 i
             )?;
         }
-        writeln!(f, "")?;
+        writeln!(f)?;
         Ok(())
     }
 }

--- a/src/synth_minidump.rs
+++ b/src/synth_minidump.rs
@@ -117,11 +117,11 @@ impl SynthMinidump {
         assert_eq!(section.size(), mem::size_of::<md::MINIDUMP_HEADER>() as u64);
 
         SynthMinidump {
-            section: section,
-            flags: flags,
+            section,
+            flags,
             stream_count: 0,
-            stream_count_label: stream_count_label,
-            stream_directory_rva: stream_directory_rva,
+            stream_count_label,
+            stream_directory_rva,
             stream_directory: Section::with_endian(endian),
             module_list: Some(List::new(
                 md::MINIDUMP_STREAM_TYPE::ModuleListStream,
@@ -299,7 +299,7 @@ impl<T: DumpSection> List<T> {
         List {
             stream_type: stream_type.into(),
             section: Section::with_endian(endian).D32(&count_label),
-            count_label: count_label,
+            count_label,
             count: 0,
             _type: PhantomData,
         }
@@ -354,7 +354,7 @@ impl DumpString {
         let section = Section::with_endian(endian)
             .D32(u16_s.len() as u32)
             .append_bytes(&u16_s);
-        DumpString { section: section }
+        DumpString { section }
     }
 }
 
@@ -422,7 +422,7 @@ impl Module {
             .D32(version_info.file_date_hi)
             .D32(version_info.file_date_lo);
         Module {
-            section: section,
+            section,
             cv_record: None,
             misc_record: None,
         }
@@ -498,10 +498,7 @@ impl Memory {
     /// Create a new `Memory` object representing memory starting at `address`,
     /// containing the contents of `section`.
     pub fn with_section(section: Section, address: u64) -> Memory {
-        Memory {
-            section: section,
-            address: address,
-        }
+        Memory { section, address }
     }
 
     // Append an `MINIDUMP_MEMORY_DESCRIPTOR` referring to this memory range to `section`.
@@ -721,7 +718,7 @@ fn test_simple_stream() {
         .flags(0x9f738b33685cc84c)
         .add_stream(SimpleStream {
             stream_type: 0x11223344,
-            section: section,
+            section,
         });
     assert_eq!(
         dump.finish().unwrap(),
@@ -789,7 +786,7 @@ fn test_simple_stream_bigendian() {
         .flags(0x9f738b33685cc84c)
         .add_stream(SimpleStream {
             stream_type: 0x11223344,
-            section: section,
+            section,
         });
     assert_eq!(
         dump.finish().unwrap(),

--- a/src/synth_minidump.rs
+++ b/src/synth_minidump.rs
@@ -60,9 +60,9 @@ impl CiteLocation for (Label, Label) {
 
 impl<T: CiteLocation> CiteLocation for Option<T> {
     fn cite_location_in(&self, section: Section) -> Section {
-        match self {
-            &Some(ref inner) => inner.cite_location_in(section),
-            &None => section.D32(0).D32(0),
+        match *self {
+            Some(ref inner) => inner.cite_location_in(section),
+            None => section.D32(0).D32(0),
         }
     }
 }
@@ -145,6 +145,8 @@ impl SynthMinidump {
     }
 
     /// Append `section` to `self`, setting its location appropriately.
+    // Perhaps should have been called .add_section().
+    #[allow(clippy::should_implement_trait)]
     pub fn add<T: DumpSection>(mut self, section: T) -> SynthMinidump {
         let offset = section.file_offset();
         self.section = self.section.mark(&offset).append_section(section);
@@ -235,6 +237,12 @@ impl SynthMinidump {
     }
 }
 
+impl Default for SynthMinidump {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DumpSection for Section {
     fn file_offset(&self) -> Label {
         self.start()
@@ -305,6 +313,8 @@ impl<T: DumpSection> List<T> {
         }
     }
 
+    // Possibly name this .add_section().
+    #[allow(clippy::should_implement_trait)]
     pub fn add(mut self, entry: T) -> List<T> {
         self.count += 1;
         self.section = self

--- a/tests/test_minidump.rs
+++ b/tests/test_minidump.rs
@@ -138,7 +138,7 @@ fn test_misc_info() {
     assert_eq!(misc_info.raw.process_create_time(), Some(0x45d35f73));
     assert_eq!(
         misc_info.process_create_time().unwrap(),
-        Utc.ymd(2007, 02, 14).and_hms(19, 13, 55)
+        Utc.ymd(2007, 2, 14).and_hms(19, 13, 55)
     );
 }
 
@@ -177,18 +177,18 @@ fn test_exception() {
     if let Some(ref ctx) = exception.context {
         assert_eq!(ctx.get_instruction_pointer(), 0x40429e);
         assert_eq!(ctx.get_stack_pointer(), 0x12fe84);
-        if let &MinidumpContext {
+        if let MinidumpContext {
             raw: MinidumpRawContext::X86(ref raw),
             ref valid,
-        } = ctx
+        } = *ctx
         {
             assert_eq!(raw.eip, 0x40429e);
             assert_eq!(*valid, MinidumpContextValidity::All);
         } else {
-            assert!(false, "Wrong context type");
+            panic!("Wrong context type");
         }
     } else {
-        assert!(false, "Missing context");
+        panic!("Missing context");
     }
 }
 
@@ -196,7 +196,7 @@ fn test_exception() {
 fn test_thread_list() {
     let dump = read_test_minidump().unwrap();
     let thread_list = dump.get_stream::<MinidumpThreadList>().unwrap();
-    let ref threads = thread_list.threads;
+    let threads = &thread_list.threads;
     assert_eq!(threads.len(), 2);
     assert_eq!(threads[0].raw.thread_id, 0xbf4);
     assert_eq!(threads[1].raw.thread_id, 0x11c0);
@@ -205,18 +205,18 @@ fn test_thread_list() {
     if let Some(ref ctx) = threads[0].context {
         assert_eq!(ctx.get_instruction_pointer(), 0x7c90eb94);
         assert_eq!(ctx.get_stack_pointer(), 0x12f320);
-        if let &MinidumpContext {
+        if let MinidumpContext {
             raw: MinidumpRawContext::X86(ref raw),
             ref valid,
-        } = ctx
+        } = *ctx
         {
             assert_eq!(raw.eip, 0x7c90eb94);
             assert_eq!(*valid, MinidumpContextValidity::All);
         } else {
-            assert!(false, "Wrong context type");
+            panic!("Wrong context type");
         }
     } else {
-        assert!(false, "Missing context");
+        panic!("Missing context");
     }
     if let Some(ref stack) = threads[0].stack {
         // Try the beginning
@@ -236,7 +236,7 @@ fn test_thread_list() {
             0x405443
         );
     } else {
-        assert!(false, "Missing stack memory");
+        panic!("Missing stack memory");
     }
 }
 


### PR DESCRIPTION
Clippy tricked me into thinking there wouldn't be much it complained about... but that was a lie.

Most of this is boring but nice to get clippy's consistency I guess.  A few things stand out though:

* I added a few `Default` impls because clippy wanted those.  That's a public API addition so perhaps deserves some more careful consideration.  We could disable these warnings if better for now.  Though if `::new()` were to change on these it would also be a public API change so perhaps than no longer being able to use `Default` or it having different semantics at that point is fine.

* I added a few `allow(clippy::should_implement_trait)` attributes, clippy complains that those methods have expectations in common traits (`std::ops::Add` in this case) and should either impl that trait or use different names.  I think using different names is probably better here, but that breaks the public API so I'm not doing that.

Happy to squash etc if you'd like, feel free to be critical.