### PR TITLE
Update to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
     "scripts/*",
     "testdata/*",
 ]
-
+edition = "2018"
 
 [dependencies]
 failure = "0.1.1"

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.rs/breakpad-symbols"
 homepage = "https://github.com/luser/rust-minidump"
 repository = "https://github.com/luser/rust-minidump"
 exclude = [ "testdata/*" ]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "luser/rust-minidump" }

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -28,25 +28,11 @@
 //!               "vswprintf");
 //! ```
 
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate log;
-extern crate minidump_common;
-#[allow(unused_imports)]
-#[macro_use]
-extern crate nom;
-extern crate range_map;
-extern crate reqwest;
-#[cfg(test)]
-extern crate tempdir;
-
-mod sym_file;
-
 use failure::Error;
-pub use minidump_common::traits::Module;
+use log::{debug, warn};
 use reqwest::blocking::Client;
 use reqwest::Url;
+
 use std::borrow::Cow;
 use std::boxed::Box;
 use std::cell::RefCell;
@@ -55,7 +41,12 @@ use std::fmt;
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-pub use sym_file::SymbolFile;
+
+pub use minidump_common::traits::Module;
+
+pub use crate::sym_file::SymbolFile;
+
+mod sym_file;
 
 /// A `Module` implementation that holds arbitrary data.
 ///

--- a/breakpad-symbols/src/sym_file/mod.rs
+++ b/breakpad-symbols/src/sym_file/mod.rs
@@ -1,15 +1,17 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-mod parser;
-mod types;
-
 use failure::Error;
+
 use std::path::Path;
 
-use sym_file::parser::{parse_symbol_bytes, parse_symbol_file};
-pub use sym_file::types::*;
-use {FrameSymbolizer, Module};
+use crate::sym_file::parser::{parse_symbol_bytes, parse_symbol_file};
+use crate::{FrameSymbolizer, Module};
+
+pub use crate::sym_file::types::*;
+
+mod parser;
+mod types;
 
 impl SymbolFile {
     /// Parse a `SymbolFile` from `path`.

--- a/breakpad-symbols/src/sym_file/parser.rs
+++ b/breakpad-symbols/src/sym_file/parser.rs
@@ -1,11 +1,11 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use failure::Error;
-use minidump_common::traits::IntoRangeMapSafe;
+use failure::{format_err, Error};
 use nom::IResult::*;
 use nom::*;
 use range_map::Range;
+
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::File;
@@ -14,7 +14,9 @@ use std::path::Path;
 use std::str;
 use std::str::FromStr;
 
-use sym_file::types::*;
+use minidump_common::traits::IntoRangeMapSafe;
+
+use crate::sym_file::types::*;
 
 enum Line<'a> {
     Info,

--- a/minidump-common/Cargo.toml
+++ b/minidump-common/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 documentation = "https://docs.rs/minidump-common"
 homepage = "https://github.com/luser/rust-minidump"
 repository = "https://github.com/luser/rust-minidump"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "luser/rust-minidump" }

--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -10,7 +10,10 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
-use scroll::{Endian, Pread};
+use bitflags::bitflags;
+use enum_primitive_derive::Primitive;
+use scroll::{Endian, Pread, SizeWith};
+use smart_default::SmartDefault;
 
 /// An offset from the start of the minidump file.
 pub type RVA = u32;

--- a/minidump-common/src/lib.rs
+++ b/minidump-common/src/lib.rs
@@ -5,19 +5,6 @@
 //! the actual functionality of reading minidumps using the structs defined in this crate.
 //!
 //! [minidump]: https://crates.io/crates/minidump
-#[macro_use]
-extern crate enum_primitive_derive;
-#[macro_use]
-extern crate bitflags;
-extern crate libc;
-#[macro_use]
-extern crate log;
-extern crate num_traits;
-extern crate range_map;
-#[macro_use]
-extern crate scroll;
-#[macro_use]
-extern crate smart_default;
 
 pub mod format;
 pub mod traits;

--- a/minidump-common/src/traits.rs
+++ b/minidump-common/src/traits.rs
@@ -1,9 +1,11 @@
 //! Some common traits used by minidump-related crates.
+
+use log::warn;
+use range_map::{Range, RangeMap};
+
 use std::borrow::Cow;
 use std::cmp;
 use std::fmt::Debug;
-
-use range_map::{Range, RangeMap};
 
 /// An executable or shared library loaded in a process.
 pub trait Module {

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 documentation = "https://docs.rs/minidump-processor"
 homepage = "https://github.com/luser/rust-minidump"
 repository = "https://github.com/luser/rust-minidump"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "luser/rust-minidump" }

--- a/minidump-processor/src/dwarf_symbolizer.rs
+++ b/minidump-processor/src/dwarf_symbolizer.rs
@@ -1,7 +1,6 @@
 use addr2line::{Context, Frame, Location};
 use failure::{bail, format_err, Error};
 use gimli::{EndianRcSlice, RunTimeEndian};
-use memmap;
 use object::{self, Object};
 
 use std::cell::RefCell;

--- a/minidump-processor/src/dwarf_symbolizer.rs
+++ b/minidump-processor/src/dwarf_symbolizer.rs
@@ -1,14 +1,17 @@
 use addr2line::{Context, Frame, Location};
-use breakpad_symbols::FrameSymbolizer;
-use failure::Error;
+use failure::{bail, format_err, Error};
 use gimli::{EndianRcSlice, RunTimeEndian};
 use memmap;
-use minidump::Module;
 use object::{self, Object};
+
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::File;
-use SymbolProvider;
+
+use breakpad_symbols::FrameSymbolizer;
+use minidump::Module;
+
+use crate::SymbolProvider;
 
 #[derive(Default)]
 pub struct DwarfSymbolizer {

--- a/minidump-processor/src/lib.rs
+++ b/minidump-processor/src/lib.rs
@@ -6,27 +6,14 @@
 //!
 //! [`process_minidump`]: fn.process_minidump.html
 
-extern crate addr2line;
-extern crate breakpad_symbols;
-extern crate chrono;
-extern crate gimli;
-extern crate memmap;
-extern crate minidump;
-extern crate object;
-#[cfg(test)]
-extern crate test_assembler;
-
-#[macro_use]
-extern crate failure;
-
 mod dwarf_symbolizer;
 mod process_state;
 mod processor;
 mod stackwalker;
 mod system_info;
 
-pub use dwarf_symbolizer::DwarfSymbolizer;
-pub use process_state::*;
-pub use processor::*;
-pub use stackwalker::*;
-pub use system_info::*;
+pub use crate::dwarf_symbolizer::DwarfSymbolizer;
+pub use crate::process_state::*;
+pub use crate::processor::*;
+pub use crate::stackwalker::*;
+pub use crate::system_info::*;

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -11,7 +11,7 @@ use std::io::prelude::*;
 use breakpad_symbols::FrameSymbolizer;
 use chrono::prelude::*;
 use minidump::*;
-use system_info::SystemInfo;
+use crate::system_info::SystemInfo;
 
 /// Indicates how well the instruction pointer derived during
 /// stack walking is trusted. Since the stack walker can resort to

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -8,10 +8,10 @@ use std::collections::HashSet;
 use std::io;
 use std::io::prelude::*;
 
+use crate::system_info::SystemInfo;
 use breakpad_symbols::FrameSymbolizer;
 use chrono::prelude::*;
 use minidump::*;
-use crate::system_info::SystemInfo;
 
 /// Indicates how well the instruction pointer derived during
 /// stack walking is trusted. Since the stack walker can resort to

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -1,14 +1,18 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use breakpad_symbols::{FrameSymbolizer, Symbolizer};
 use chrono::{TimeZone, Utc};
-use minidump::{self, *};
-use process_state::{CallStack, CallStackInfo, ProcessState};
-use stackwalker;
+use failure::Fail;
+
 use std::boxed::Box;
 use std::ops::Deref;
-use system_info::SystemInfo;
+
+use breakpad_symbols::{FrameSymbolizer, Symbolizer};
+use minidump::{self, *};
+
+use crate::process_state::{CallStack, CallStackInfo, ProcessState};
+use crate::stackwalker;
+use crate::system_info::SystemInfo;
 
 pub trait SymbolProvider {
     fn fill_symbol(&self, module: &dyn Module, frame: &mut dyn FrameSymbolizer);

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -6,9 +6,9 @@
 mod unwind;
 mod x86;
 
-use minidump::*;
 use crate::process_state::*;
 use crate::SymbolProvider;
+use minidump::*;
 
 use self::unwind::Unwind;
 

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -7,8 +7,8 @@ mod unwind;
 mod x86;
 
 use minidump::*;
-use process_state::*;
-use SymbolProvider;
+use crate::process_state::*;
+use crate::SymbolProvider;
 
 use self::unwind::Unwind;
 

--- a/minidump-processor/src/stackwalker/unwind.rs
+++ b/minidump-processor/src/stackwalker/unwind.rs
@@ -2,7 +2,7 @@
 // file at the top-level directory of this distribution.
 
 use minidump::{MinidumpContextValidity, MinidumpMemory};
-use process_state::StackFrame;
+use crate::process_state::StackFrame;
 
 /// A trait for things that can unwind to a caller.
 pub trait Unwind {

--- a/minidump-processor/src/stackwalker/unwind.rs
+++ b/minidump-processor/src/stackwalker/unwind.rs
@@ -1,8 +1,8 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use minidump::{MinidumpContextValidity, MinidumpMemory};
 use crate::process_state::StackFrame;
+use minidump::{MinidumpContextValidity, MinidumpMemory};
 
 /// A trait for things that can unwind to a caller.
 pub trait Unwind {

--- a/minidump-processor/src/stackwalker/x86.rs
+++ b/minidump-processor/src/stackwalker/x86.rs
@@ -1,10 +1,10 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use minidump::format::CONTEXT_X86;
-use minidump::{MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpRawContext};
 use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
+use minidump::format::CONTEXT_X86;
+use minidump::{MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpRawContext};
 use std::collections::HashSet;
 
 fn get_caller_by_frame_pointer(

--- a/minidump-processor/src/stackwalker/x86.rs
+++ b/minidump-processor/src/stackwalker/x86.rs
@@ -3,8 +3,8 @@
 
 use minidump::format::CONTEXT_X86;
 use minidump::{MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpRawContext};
-use process_state::{FrameTrust, StackFrame};
-use stackwalker::unwind::Unwind;
+use crate::process_state::{FrameTrust, StackFrame};
+use crate::stackwalker::unwind::Unwind;
 use std::collections::HashSet;
 
 fn get_caller_by_frame_pointer(

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -1,11 +1,11 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
 use breakpad_symbols::{SimpleSymbolSupplier, Symbolizer};
 use minidump::format::CONTEXT_X86;
 use minidump::*;
-use crate::process_state::*;
-use crate::stackwalker::walk_stack;
 use test_assembler::*;
 
 struct TestFixture {

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -4,8 +4,8 @@
 use breakpad_symbols::{SimpleSymbolSupplier, Symbolizer};
 use minidump::format::CONTEXT_X86;
 use minidump::*;
-use process_state::*;
-use stackwalker::walk_stack;
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
 use test_assembler::*;
 
 struct TestFixture {

--- a/minidump-tools/Cargo.toml
+++ b/minidump-tools/Cargo.toml
@@ -2,6 +2,7 @@
 name = "minidump-tools"
 version = "0.2.0"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
+edition = "2018"
 
 [dependencies]
 breakpad-symbols = { version = "0.1.1", path = "../breakpad-symbols" }

--- a/minidump-tools/src/lib.rs
+++ b/minidump-tools/src/lib.rs
@@ -1,31 +1,20 @@
-extern crate breakpad_symbols;
-extern crate disasm;
-extern crate env_logger;
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate log;
-extern crate minidump;
-extern crate minidump_common;
-extern crate reqwest;
-#[allow(unused_imports)]
-#[macro_use]
-extern crate structopt;
+use disasm::{Color, CpuArch, SourceLocation, SourceLookup};
+use failure::{bail, format_err, Error};
+use log::{debug, info};
+use reqwest::blocking::Client;
+
+use std::env;
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use structopt::StructOpt;
 
 use breakpad_symbols::{HttpSymbolSupplier, SimpleFrame, Symbolizer};
-use disasm::{Color, CpuArch, SourceLocation, SourceLookup};
-use failure::Error;
 use minidump::system_info::Cpu;
 use minidump::{
     Minidump, MinidumpException, MinidumpMemoryList, MinidumpModule, MinidumpModuleList,
     MinidumpSystemInfo,
 };
 use minidump_common::traits::Module;
-use reqwest::blocking::Client;
-use std::env;
-use std::fs::{self, File};
-use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,7 +10,7 @@ use std::io;
 use std::io::prelude::*;
 use std::mem;
 
-use iostuff::*;
+use crate::iostuff::*;
 use minidump_common::format as md;
 use minidump_common::format::ContextFlagsCpu;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,21 +19,6 @@
 //! [read]: struct.Minidump.html#method.read
 //! [read_path]: struct.Minidump.html#method.read_path
 
-extern crate chrono;
-extern crate encoding;
-#[macro_use]
-extern crate failure;
-#[cfg(doctest)]
-extern crate doc_comment;
-extern crate libc;
-extern crate memmap;
-extern crate minidump_common;
-extern crate num_traits;
-extern crate range_map;
-extern crate scroll;
-#[cfg(test)]
-extern crate test_assembler;
-
 #[cfg(doctest)]
 doc_comment::doctest!("../README.md");
 
@@ -46,7 +31,7 @@ mod minidump;
 pub mod synth_minidump;
 pub mod system_info;
 
-pub use iostuff::Readable;
-pub use minidump::*;
+pub use crate::iostuff::Readable;
+pub use crate::minidump::*;
 pub use minidump_common::format;
 pub use minidump_common::traits::Module;

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -4,7 +4,7 @@
 use chrono::prelude::*;
 use encoding::all::UTF_16LE;
 use encoding::{DecoderTrap, Encoding};
-use failure;
+use failure::Fail;
 use memmap::Mmap;
 use num_traits::FromPrimitive;
 use scroll::ctx::{SizeWith, TryFromCtx};
@@ -23,12 +23,12 @@ use std::ops::Deref;
 use std::path::Path;
 use std::str;
 
-pub use context::*;
+pub use crate::context::*;
+use crate::system_info::{Cpu, Os};
 use minidump_common::format as md;
 use minidump_common::format::{CvSignature, MINIDUMP_STREAM_TYPE};
 use minidump_common::traits::{IntoRangeMapSafe, Module};
 use range_map::{Range, RangeMap};
-use system_info::{Cpu, Os};
 
 /// An index into the contents of a minidump.
 ///
@@ -1686,10 +1686,10 @@ MDRawDirectory
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::synth_minidump::Module as SynthModule;
+    use crate::synth_minidump::{self, MiscStream, SimpleStream, SynthMinidump, Thread};
+    use crate::synth_minidump::{DumpString, Memory, STOCK_VERSION_INFO};
     use std::mem;
-    use synth_minidump::Module as SynthModule;
-    use synth_minidump::{self, MiscStream, SimpleStream, SynthMinidump, Thread};
-    use synth_minidump::{DumpString, Memory, STOCK_VERSION_INFO};
     use test_assembler::*;
 
     fn read_synth_dump<'a>(dump: SynthMinidump) -> Result<Minidump<'a, Vec<u8>>, Error> {


### PR DESCRIPTION
As you seem to be happy updating the code, I've adopted this to the 2018 edition.  Other than the strictly required `cargo fix --edition` this also replaces the `extern crate` statements with explicit `use` statements.

I realise this is a bit of a gratuitous change, so I won't mind at all if you'd rather not update the edition.