### PR TITLE
Fix memory region and stream lifetimes

### DIFF
--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -1906,6 +1906,10 @@ where
     /// [`MinidumpStream`][stream] trait, this method allows reading
     /// the stream data as a specific type.
     ///
+    /// Note that the lifetime of the returned stream is bound to the lifetime of the this
+    /// `Minidump` struct itself and not to the lifetime of the data backing this minidump.
+    /// This is a consequence of how this struct relies on [Deref] to access the data.
+    ///
     /// [stream]: trait.MinidumpStream.html
     pub fn get_stream<S>(&'a self) -> Result<S, Error>
     where
@@ -1925,6 +1929,10 @@ where
     /// This can be used to get the contents of arbitrary minidump streams.
     /// For streams of known types you almost certainly want to use
     /// [`get_stream`][get_stream] instead.
+    ///
+    /// Note that the lifetime of the returned stream is bound to the lifetime of the this
+    /// `Minidump` struct itself and not to the lifetime of the data backing this minidump.
+    /// This is a consequence of how this struct relies on [Deref] to access the data.
     ///
     /// [get_stream]: #get_stream
     pub fn get_raw_stream<S>(&'a self, stream_type: S) -> Result<&'a [u8], Error>

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -1902,10 +1902,9 @@ where
     /// the stream data as a specific type.
     ///
     /// [stream]: trait.MinidumpStream.html
-    pub fn get_stream<'b, S>(&'b self) -> Result<S, Error>
+    pub fn get_stream<S>(&'a self) -> Result<S, Error>
     where
         S: MinidumpStream<'a>,
-        'b: 'a,
     {
         match self.get_raw_stream(S::STREAM_TYPE) {
             Err(e) => Err(e),
@@ -1923,10 +1922,9 @@ where
     /// [`get_stream`][get_stream] instead.
     ///
     /// [get_stream]: #get_stream
-    pub fn get_raw_stream<'b, S>(&'b self, stream_type: S) -> Result<&'a [u8], Error>
+    pub fn get_raw_stream<S>(&'a self, stream_type: S) -> Result<&'a [u8], Error>
     where
         S: Into<u32>,
-        'b: 'a,
     {
         match self.streams.get(&stream_type.into()) {
             None => Err(Error::StreamNotFound),

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -2250,7 +2250,7 @@ mod test {
 
     #[test]
     fn test_memory_list_lifetimes() {
-        // A memory list should not own any of it's data.
+        // A memory list should not own any of the minidump data.
         const CONTENTS: &[u8] = b"memory_contents";
         let memory = Memory::with_section(
             Section::with_endian(Endian::Little).append_bytes(CONTENTS),


### PR DESCRIPTION
Self can directly be of lifetime 'a, constraining it to a different
lifetime does not seem to gain any more flexibility.  This simplifies
the signature and thus use.

I don't think there are backwards compatibility concerns with this,
everything which was possible should still be possible.  The lifetime
of the returned stream is still the same 'a as before.