### PR TITLE
Use stable rustc for docs CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,11 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           profile: minimal
           components: rust-docs
           override: true
       - uses: swatinem/rust-cache@v1
-        with:
-          key: ${{ github.job }}
       - uses: actions-rs/cargo@v1
         with:
           command: doc
@@ -79,8 +77,6 @@ jobs:
           profile: minimal
           override: true
       - uses: swatinem/rust-cache@v1
-        with:
-          key: ${{ github.job }}
       - uses: actions-rs/cargo@v1
         env:
           PWD: ${{ env.GITHUB_WORKSPACE }}


### PR DESCRIPTION
The intra-doc linking now works on rust stable.  No need to use
nightly anymore.

Also update caching action which is simpler to use in more recent
versions.