### PR TITLE
Fix Rust Edition 2018 idioms

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ It's fairly heavily modeled after the [Google Breakpad](https://chromium.googles
 Print the raw details of the exception stream from a minidump:
 
 ```rust
-extern crate minidump;
-
 use minidump::{Error, Minidump, MinidumpException, MinidumpStream};
 use std::io::{self, Write};
 

--- a/examples/dumpmodules.rs
+++ b/examples/dumpmodules.rs
@@ -6,9 +6,6 @@ use std::ffi::OsStr;
 use std::io::Write;
 use std::path::Path;
 
-extern crate minidump;
-extern crate minidump_common;
-
 use minidump::*;
 use minidump_common::traits::Module;
 

--- a/minidump-processor/src/bin/minidump_stackwalk.rs
+++ b/minidump-processor/src/bin/minidump_stackwalk.rs
@@ -6,10 +6,6 @@ use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
-extern crate breakpad_symbols;
-extern crate minidump;
-extern crate minidump_processor;
-
 use breakpad_symbols::{SimpleSymbolSupplier, Symbolizer};
 use minidump::*;
 use minidump_processor::{DwarfSymbolizer, MultiSymbolProvider};

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -71,10 +71,6 @@ impl From<minidump::Error> for ProcessError {
 /// # Examples
 ///
 /// ```
-/// extern crate breakpad_symbols;
-/// extern crate minidump;
-/// extern crate minidump_processor;
-///
 /// use minidump::Minidump;
 /// use std::path::PathBuf;
 /// use breakpad_symbols::{Symbolizer, SimpleSymbolSupplier};

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -1,12 +1,6 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-extern crate breakpad_symbols;
-extern crate failure;
-extern crate memmap;
-extern crate minidump;
-extern crate minidump_processor;
-
 use breakpad_symbols::{SimpleSymbolSupplier, Symbolizer};
 use minidump::system_info::{Cpu, Os};
 use minidump::*;

--- a/minidump-tools/src/bin/dumpstack.rs
+++ b/minidump-tools/src/bin/dumpstack.rs
@@ -1,5 +1,3 @@
-extern crate minidump_tools;
-
 use std::process;
 
 fn main() {

--- a/minidump-tools/src/bin/get-minidump-instructions.rs
+++ b/minidump-tools/src/bin/get-minidump-instructions.rs
@@ -1,5 +1,3 @@
-extern crate minidump_tools;
-
 use std::process;
 
 fn main() {

--- a/src/bin/minidump_dump.rs
+++ b/src/bin/minidump_dump.rs
@@ -6,9 +6,6 @@ use std::io::{self, Write};
 use std::path::Path;
 use std::str;
 
-extern crate minidump;
-extern crate minidump_common;
-
 use minidump::*;
 
 const USAGE: &str = "Usage: minidump_dump <minidump>";
@@ -34,13 +31,13 @@ fn print_minidump_dump(path: &Path) {
         Ok(dump) => {
             let stdout = &mut std::io::stdout();
             dump.print(stdout).unwrap();
-            if let Ok(thread_list) = dump.get_stream::<MinidumpThreadList>() {
+            if let Ok(thread_list) = dump.get_stream::<MinidumpThreadList<'_>>() {
                 thread_list.print(stdout).unwrap();
             }
             if let Ok(module_list) = dump.get_stream::<MinidumpModuleList>() {
                 module_list.print(stdout).unwrap();
             }
-            if let Ok(memory_list) = dump.get_stream::<MinidumpMemoryList>() {
+            if let Ok(memory_list) = dump.get_stream::<MinidumpMemoryList<'_>>() {
                 memory_list.print(stdout).unwrap();
             }
             // TODO: MemoryList

--- a/src/system_info.rs
+++ b/src/system_info.rs
@@ -45,7 +45,7 @@ impl Os {
     }
 
     /// Get a human-readable friendly name for an `Os`
-    pub fn long_name(&self) -> Cow<str> {
+    pub fn long_name(&self) -> Cow<'_, str> {
         match *self {
             Os::Windows => Cow::Borrowed("Windows"),
             Os::MacOs => Cow::Borrowed("Mac OS X"),
@@ -61,7 +61,7 @@ impl Os {
 }
 
 impl fmt::Display for Os {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",
@@ -117,7 +117,7 @@ impl Cpu {
 }
 
 impl fmt::Display for Cpu {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",

--- a/tests/test_minidump.rs
+++ b/tests/test_minidump.rs
@@ -1,13 +1,6 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-extern crate chrono;
-extern crate failure;
-extern crate memmap;
-extern crate minidump;
-extern crate minidump_common;
-extern crate num_traits;
-
 use chrono::prelude::*;
 use memmap::Mmap;
 use minidump::system_info::{Cpu, Os};
@@ -195,7 +188,7 @@ fn test_exception() {
 #[test]
 fn test_thread_list() {
     let dump = read_test_minidump().unwrap();
-    let thread_list = dump.get_stream::<MinidumpThreadList>().unwrap();
+    let thread_list = dump.get_stream::<MinidumpThreadList<'_>>().unwrap();
     let threads = &thread_list.threads;
     assert_eq!(threads.len(), 2);
     assert_eq!(threads[0].raw.thread_id, 0xbf4);


### PR DESCRIPTION
This is a follow-up to #109, applying `cargo fix --edition-idioms` and removing all `extern crate` declarations.

cc @flub 