### PR TITLE
Fix a panic in location_slice

### DIFF
--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -321,11 +321,7 @@ fn location_slice<'a>(
 ) -> Result<&'a [u8], Error> {
     let start = loc.rva as usize;
     let end = (loc.rva + loc.data_size) as usize;
-    if start < bytes.len() && end <= bytes.len() {
-        Ok(&bytes[start..end])
-    } else {
-        Err(Error::StreamReadFailure)
-    }
+    bytes.get(start..end).ok_or(Error::StreamReadFailure)
 }
 
 /// Read a u32 length-prefixed UTF-16 string from `bytes` at `offset`.


### PR DESCRIPTION
If `loc.data_size` is the equivalent of a negative number, then in production
builds the end index will wrap around and be smaller than the start index.
The `slice::get` method conveniently checks for all that already, so we can use
that instead.

Note that I left the cast for `end` outside of the addition, since it is
convenient to see the wraparound happen.
