### PR TITLE
Parse the MISC_INFO_5 format in minidumps

### DIFF
--- a/tests/test_minidump.rs
+++ b/tests/test_minidump.rs
@@ -127,8 +127,8 @@ fn test_system_info() {
 fn test_misc_info() {
     let dump = read_test_minidump().unwrap();
     let misc_info = dump.get_stream::<MinidumpMiscInfo>().unwrap();
-    assert_eq!(misc_info.raw.process_id(), Some(3932));
-    assert_eq!(misc_info.raw.process_create_time(), Some(0x45d35f73));
+    assert_eq!(misc_info.raw.process_id(), Some(&3932));
+    assert_eq!(misc_info.raw.process_create_time(), Some(&0x45d35f73));
     assert_eq!(
         misc_info.process_create_time().unwrap(),
         Utc.ymd(2007, 2, 14).and_hms(19, 13, 55)


### PR DESCRIPTION
Fixes #16

This is a bit messy because I misunderstood the scope of #16 and started working towards actually walking through the XSAVE entries that MISC_INFO_5 describes before realizing that wasn't actually desired at the moment. So this has some extra "useless" definitions that cover what the meaning of the enabled_features bitfield is, but I figured I'd leave it there in case it's ever desirable to properly process that data.