### PR TITLE
Fix acronym and panic warnings

### DIFF
--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -491,10 +491,8 @@ impl Symbolizer {
             debug!("locate_symbols for {}: {}", module.code_file(), res);
             self.symbols.borrow_mut().insert(k.clone(), res);
         }
-        if let Some(res) = self.symbols.borrow().get(&k) {
-            if let SymbolResult::Ok(ref sym) = *res {
-                sym.fill_symbol(module, frame)
-            }
+        if let Some(SymbolResult::Ok(ref sym)) = self.symbols.borrow().get(&k) {
+            sym.fill_symbol(module, frame)
         }
     }
 }
@@ -657,6 +655,7 @@ mod test {
             // Should load OK now that it exists.
             assert!(
                 matches!(supplier.locate_symbols(&m), SymbolResult::Ok(_)),
+                "{}",
                 format!("Located symbols for {}", sym)
             );
         }
@@ -669,6 +668,7 @@ mod test {
         let res = supplier.locate_symbols(&mal);
         assert!(
             matches!(res, SymbolResult::LoadError(_)),
+            "{}",
             format!("Correctly failed to parse {}, result: {:?}", sym, res)
         );
     }

--- a/breakpad-symbols/src/sym_file/types.rs
+++ b/breakpad-symbols/src/sym_file/types.rs
@@ -78,7 +78,7 @@ impl Function {
 
 /// DWARF CFI rules for recovering registers at a specific address.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct CFIRules {
+pub struct CfiRules {
     /// The address in question.
     pub address: u64,
     /// Postfix expressions to evaluate to recover register values.
@@ -87,16 +87,16 @@ pub struct CFIRules {
 
 /// Information used for unwinding stack frames using DWARF CFI.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct StackInfoCFI {
+pub struct StackInfoCfi {
     /// The initial rules for this address range.
-    pub init: CFIRules,
+    pub init: CfiRules,
     /// The size of this entire address range.
     pub size: u32,
     /// Additional rules to use at specified addresses.
-    pub add_rules: Vec<CFIRules>,
+    pub add_rules: Vec<CfiRules>,
 }
 
-impl StackInfoCFI {
+impl StackInfoCfi {
     pub fn memory_range(&self) -> Range<u64> {
         Range::new(self.init.address, self.init.address + self.size as u64 - 1)
     }
@@ -107,7 +107,7 @@ impl StackInfoCFI {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum WinFrameType {
     /// This frame uses FPO-style data.
-    FPO(StackInfoWin),
+    Fpo(StackInfoWin),
     /// This frame uses new-style frame data, has a program string.
     FrameData(StackInfoWin),
     /// Some other type of frame.
@@ -159,7 +159,7 @@ pub struct SymbolFile {
     /// Functions.
     pub functions: RangeMap<u64, Function>,
     /// DWARF CFI unwind information.
-    pub cfi_stack_info: RangeMap<u64, StackInfoCFI>,
+    pub cfi_stack_info: RangeMap<u64, StackInfoCfi>,
     /// Windows unwind information (frame data).
     pub win_stack_framedata_info: RangeMap<u64, StackInfoWin>,
     /// Windows unwind information (FPO data).

--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -9,6 +9,7 @@
 //! [crashpad]: https://chromium.googlesource.com/crashpad/crashpad/+/master/README.md
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
+#![allow(clippy::upper_case_acronyms)]
 
 use bitflags::bitflags;
 use enum_primitive_derive::Primitive;
@@ -224,9 +225,9 @@ pub enum MINIDUMP_STREAM_TYPE {
     CrashpadInfoStream = 0x43500001,
 }
 
-impl Into<u32> for MINIDUMP_STREAM_TYPE {
-    fn into(self) -> u32 {
-        self as u32
+impl From<MINIDUMP_STREAM_TYPE> for u32 {
+    fn from(ty: MINIDUMP_STREAM_TYPE) -> Self {
+        ty as u32
     }
 }
 

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -98,7 +98,7 @@ pub enum CallStackInfo {
     /// No stack memory was provided, couldn't unwind past the top frame.
     MissingMemory,
     /// The CPU type is unsupported.
-    UnsupportedCPU,
+    UnsupportedCpu,
     /// This thread wrote the minidump, it was skipped.
     DumpThreadSkipped,
 }

--- a/minidump-tools/src/lib.rs
+++ b/minidump-tools/src/lib.rs
@@ -66,13 +66,13 @@ struct GitHubFile {
     path: String,
 }
 
-trait VCSFile {
+trait VcsFile {
     fn raw_url(&self) -> String;
     fn annotate_url(&self, line: u64) -> String;
     fn as_local_filename(&self) -> String;
 }
 
-impl VCSFile for HgWebFile {
+impl VcsFile for HgWebFile {
     fn raw_url(&self) -> String {
         format!(
             "https://{}/{}/raw-file/{}/{}",
@@ -91,7 +91,7 @@ impl VCSFile for HgWebFile {
     }
 }
 
-impl VCSFile for GitHubFile {
+impl VcsFile for GitHubFile {
     fn raw_url(&self) -> String {
         format!(
             "http://raw.githubusercontent.com/{}/{}/{}",
@@ -127,7 +127,7 @@ fn fetch_url_to_path(client: &Client, url: &str, path: &Path) -> Result<(), Erro
     Ok(())
 }
 
-fn parse_vcs_info(filename: &str) -> Result<Box<dyn VCSFile>, Error> {
+fn parse_vcs_info(filename: &str) -> Result<Box<dyn VcsFile>, Error> {
     let mut bits = filename.split(':');
     Ok(match (bits.next(), bits.next(), bits.next(), bits.next()) {
         (Some("hg"), Some(repo), Some(path), Some(rev)) if repo.starts_with("hg.mozilla.org/") => {

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,18 +18,18 @@ use minidump_common::format::ContextFlagsCpu;
 #[derive(Clone)]
 pub enum MinidumpRawContext {
     X86(md::CONTEXT_X86),
-    PPC(md::CONTEXT_PPC),
-    PPC64(md::CONTEXT_PPC64),
-    AMD64(md::CONTEXT_AMD64),
-    SPARC(md::CONTEXT_SPARC),
-    ARM(md::CONTEXT_ARM),
-    ARM64(md::CONTEXT_ARM64),
-    OLDARM64(md::CONTEXT_ARM64_OLD),
-    MIPS(md::CONTEXT_MIPS),
+    Ppc(md::CONTEXT_PPC),
+    Ppc64(md::CONTEXT_PPC64),
+    Amd64(md::CONTEXT_AMD64),
+    Sparc(md::CONTEXT_SPARC),
+    Arm(md::CONTEXT_ARM),
+    Arm64(md::CONTEXT_ARM64),
+    OldArm64(md::CONTEXT_ARM64_OLD),
+    Mips(md::CONTEXT_MIPS),
 }
 
 /// Generic over the specifics of a CPU context.
-pub trait CPUContext {
+pub trait CpuContext {
     /// The word size of general-purpose registers in the context.
     type Register: fmt::LowerHex;
 
@@ -60,7 +60,7 @@ pub trait CPUContext {
     fn get_register_always(&self, reg: &str) -> Self::Register;
 }
 
-impl CPUContext for md::CONTEXT_X86 {
+impl CpuContext for md::CONTEXT_X86 {
     type Register = u32;
 
     fn get_register_always(&self, reg: &str) -> u32 {
@@ -80,7 +80,7 @@ impl CPUContext for md::CONTEXT_X86 {
     }
 }
 
-impl CPUContext for md::CONTEXT_AMD64 {
+impl CpuContext for md::CONTEXT_AMD64 {
     type Register = u64;
 
     fn get_register_always(&self, reg: &str) -> u64 {
@@ -107,7 +107,7 @@ impl CPUContext for md::CONTEXT_AMD64 {
     }
 }
 
-impl CPUContext for md::CONTEXT_ARM64_OLD {
+impl CpuContext for md::CONTEXT_ARM64_OLD {
     type Register = u64;
 
     fn get_register_always(&self, reg: &str) -> u64 {
@@ -152,7 +152,7 @@ impl CPUContext for md::CONTEXT_ARM64_OLD {
     }
 }
 
-impl CPUContext for md::CONTEXT_ARM64 {
+impl CpuContext for md::CONTEXT_ARM64 {
     type Register = u64;
 
     fn get_register_always(&self, reg: &str) -> u64 {
@@ -231,7 +231,7 @@ pub enum ContextError {
     /// Failed to read data.
     ReadFailure,
     /// Encountered an unknown CPU context.
-    UnknownCPUContext,
+    UnknownCpuContext,
 }
 
 /// General-purpose registers for x86.
@@ -275,7 +275,7 @@ impl MinidumpContext {
             if ContextFlagsCpu::from_flags(ctx.context_flags) != ContextFlagsCpu::CONTEXT_AMD64 {
                 return Err(ContextError::ReadFailure);
             } else {
-                return Ok(MinidumpContext::from_raw(MinidumpRawContext::AMD64(ctx)));
+                return Ok(MinidumpContext::from_raw(MinidumpRawContext::Amd64(ctx)));
             }
         } else if bytes.len() == mem::size_of::<md::CONTEXT_PPC64>() {
             let ctx: md::CONTEXT_PPC64 = bytes
@@ -286,7 +286,7 @@ impl MinidumpContext {
             {
                 return Err(ContextError::ReadFailure);
             } else {
-                return Ok(MinidumpContext::from_raw(MinidumpRawContext::PPC64(ctx)));
+                return Ok(MinidumpContext::from_raw(MinidumpRawContext::Ppc64(ctx)));
             }
         } else if bytes.len() == mem::size_of::<md::CONTEXT_ARM64_OLD>() {
             let ctx: md::CONTEXT_ARM64_OLD = bytes
@@ -297,7 +297,7 @@ impl MinidumpContext {
             {
                 return Err(ContextError::ReadFailure);
             } else {
-                return Ok(MinidumpContext::from_raw(MinidumpRawContext::OLDARM64(ctx)));
+                return Ok(MinidumpContext::from_raw(MinidumpRawContext::OldArm64(ctx)));
             }
         }
 
@@ -320,75 +320,75 @@ impl MinidumpContext {
                 let ctx: md::CONTEXT_PPC = bytes
                     .gread_with(&mut offset, endian)
                     .or(Err(ContextError::ReadFailure))?;
-                Ok(MinidumpContext::from_raw(MinidumpRawContext::PPC(ctx)))
+                Ok(MinidumpContext::from_raw(MinidumpRawContext::Ppc(ctx)))
             }
             ContextFlagsCpu::CONTEXT_SPARC => {
                 let ctx: md::CONTEXT_SPARC = bytes
                     .gread_with(&mut offset, endian)
                     .or(Err(ContextError::ReadFailure))?;
-                Ok(MinidumpContext::from_raw(MinidumpRawContext::SPARC(ctx)))
+                Ok(MinidumpContext::from_raw(MinidumpRawContext::Sparc(ctx)))
             }
             ContextFlagsCpu::CONTEXT_ARM => {
                 let ctx: md::CONTEXT_ARM = bytes
                     .gread_with(&mut offset, endian)
                     .or(Err(ContextError::ReadFailure))?;
-                Ok(MinidumpContext::from_raw(MinidumpRawContext::ARM(ctx)))
+                Ok(MinidumpContext::from_raw(MinidumpRawContext::Arm(ctx)))
             }
             ContextFlagsCpu::CONTEXT_MIPS => {
                 let ctx: md::CONTEXT_MIPS = bytes
                     .gread_with(&mut offset, endian)
                     .or(Err(ContextError::ReadFailure))?;
-                Ok(MinidumpContext::from_raw(MinidumpRawContext::MIPS(ctx)))
+                Ok(MinidumpContext::from_raw(MinidumpRawContext::Mips(ctx)))
             }
             ContextFlagsCpu::CONTEXT_ARM64 => {
                 let ctx: md::CONTEXT_ARM64 = bytes
                     .gread_with(&mut offset, endian)
                     .or(Err(ContextError::ReadFailure))?;
-                Ok(MinidumpContext::from_raw(MinidumpRawContext::ARM64(ctx)))
+                Ok(MinidumpContext::from_raw(MinidumpRawContext::Arm64(ctx)))
             }
-            _ => Err(ContextError::UnknownCPUContext),
+            _ => Err(ContextError::UnknownCpuContext),
         }
     }
 
     pub fn get_instruction_pointer(&self) -> u64 {
         match self.raw {
-            MinidumpRawContext::AMD64(ref ctx) => ctx.rip,
-            MinidumpRawContext::ARM(ref ctx) => {
+            MinidumpRawContext::Amd64(ref ctx) => ctx.rip,
+            MinidumpRawContext::Arm(ref ctx) => {
                 ctx.iregs[md::ArmRegisterNumbers::ProgramCounter as usize] as u64
             }
-            MinidumpRawContext::ARM64(ref ctx) => ctx.pc,
-            MinidumpRawContext::OLDARM64(ref ctx) => ctx.pc,
-            MinidumpRawContext::PPC(ref ctx) => ctx.srr0 as u64,
-            MinidumpRawContext::PPC64(ref ctx) => ctx.srr0,
-            MinidumpRawContext::SPARC(ref ctx) => ctx.pc,
+            MinidumpRawContext::Arm64(ref ctx) => ctx.pc,
+            MinidumpRawContext::OldArm64(ref ctx) => ctx.pc,
+            MinidumpRawContext::Ppc(ref ctx) => ctx.srr0 as u64,
+            MinidumpRawContext::Ppc64(ref ctx) => ctx.srr0,
+            MinidumpRawContext::Sparc(ref ctx) => ctx.pc,
             MinidumpRawContext::X86(ref ctx) => ctx.eip as u64,
-            MinidumpRawContext::MIPS(ref ctx) => ctx.epc,
+            MinidumpRawContext::Mips(ref ctx) => ctx.epc,
         }
     }
 
     pub fn get_stack_pointer(&self) -> u64 {
         match self.raw {
-            MinidumpRawContext::AMD64(ref ctx) => ctx.rsp,
-            MinidumpRawContext::ARM(ref ctx) => {
+            MinidumpRawContext::Amd64(ref ctx) => ctx.rsp,
+            MinidumpRawContext::Arm(ref ctx) => {
                 ctx.iregs[md::ArmRegisterNumbers::StackPointer as usize] as u64
             }
-            MinidumpRawContext::ARM64(ref ctx) => {
+            MinidumpRawContext::Arm64(ref ctx) => {
                 ctx.iregs[md::Arm64RegisterNumbers::StackPointer as usize]
             }
-            MinidumpRawContext::OLDARM64(ref ctx) => {
+            MinidumpRawContext::OldArm64(ref ctx) => {
                 ctx.iregs[md::Arm64RegisterNumbers::StackPointer as usize]
             }
-            MinidumpRawContext::PPC(ref ctx) => {
+            MinidumpRawContext::Ppc(ref ctx) => {
                 ctx.gpr[md::PpcRegisterNumbers::StackPointer as usize] as u64
             }
-            MinidumpRawContext::PPC64(ref ctx) => {
+            MinidumpRawContext::Ppc64(ref ctx) => {
                 ctx.gpr[md::Ppc64RegisterNumbers::StackPointer as usize]
             }
-            MinidumpRawContext::SPARC(ref ctx) => {
+            MinidumpRawContext::Sparc(ref ctx) => {
                 ctx.g_r[md::SparcRegisterNumbers::StackPointer as usize]
             }
             MinidumpRawContext::X86(ref ctx) => ctx.esp as u64,
-            MinidumpRawContext::MIPS(ref ctx) => {
+            MinidumpRawContext::Mips(ref ctx) => {
                 ctx.iregs[md::MipsRegisterNumbers::StackPointer as usize]
             }
         }
@@ -396,29 +396,29 @@ impl MinidumpContext {
 
     pub fn format_register(&self, reg: &str) -> String {
         match self.raw {
-            MinidumpRawContext::AMD64(ref ctx) => ctx.format_register(reg),
-            MinidumpRawContext::ARM(_) => unimplemented!(),
-            MinidumpRawContext::ARM64(ref ctx) => ctx.format_register(reg),
-            MinidumpRawContext::OLDARM64(ref ctx) => ctx.format_register(reg),
-            MinidumpRawContext::PPC(_) => unimplemented!(),
-            MinidumpRawContext::PPC64(_) => unimplemented!(),
-            MinidumpRawContext::SPARC(_) => unimplemented!(),
+            MinidumpRawContext::Amd64(ref ctx) => ctx.format_register(reg),
+            MinidumpRawContext::Arm(_) => unimplemented!(),
+            MinidumpRawContext::Arm64(ref ctx) => ctx.format_register(reg),
+            MinidumpRawContext::OldArm64(ref ctx) => ctx.format_register(reg),
+            MinidumpRawContext::Ppc(_) => unimplemented!(),
+            MinidumpRawContext::Ppc64(_) => unimplemented!(),
+            MinidumpRawContext::Sparc(_) => unimplemented!(),
             MinidumpRawContext::X86(ref ctx) => ctx.format_register(reg),
-            MinidumpRawContext::MIPS(_) => unimplemented!(),
+            MinidumpRawContext::Mips(_) => unimplemented!(),
         }
     }
 
     pub fn general_purpose_registers(&self) -> &'static [&'static str] {
         match self.raw {
-            MinidumpRawContext::AMD64(_) => &X86_64_REGS[..],
-            MinidumpRawContext::ARM(_) => unimplemented!(),
-            MinidumpRawContext::ARM64(_) => &ARM64_REGS[..],
-            MinidumpRawContext::OLDARM64(_) => &ARM64_REGS[..],
-            MinidumpRawContext::PPC(_) => unimplemented!(),
-            MinidumpRawContext::PPC64(_) => unimplemented!(),
-            MinidumpRawContext::SPARC(_) => unimplemented!(),
+            MinidumpRawContext::Amd64(_) => &X86_64_REGS[..],
+            MinidumpRawContext::Arm(_) => unimplemented!(),
+            MinidumpRawContext::Arm64(_) => &ARM64_REGS[..],
+            MinidumpRawContext::OldArm64(_) => &ARM64_REGS[..],
+            MinidumpRawContext::Ppc(_) => unimplemented!(),
+            MinidumpRawContext::Ppc64(_) => unimplemented!(),
+            MinidumpRawContext::Sparc(_) => unimplemented!(),
             MinidumpRawContext::X86(_) => &X86_REGS[..],
-            MinidumpRawContext::MIPS(_) => unimplemented!(),
+            MinidumpRawContext::Mips(_) => unimplemented!(),
         }
     }
 
@@ -506,13 +506,13 @@ impl MinidumpContext {
                 write_bytes(f, &raw.extended_registers)?;
                 write!(f, "\n\n")?;
             }
-            MinidumpRawContext::PPC(_) => {
+            MinidumpRawContext::Ppc(_) => {
                 unimplemented!();
             }
-            MinidumpRawContext::PPC64(_) => {
+            MinidumpRawContext::Ppc64(_) => {
                 unimplemented!();
             }
-            MinidumpRawContext::AMD64(ref raw) => {
+            MinidumpRawContext::Amd64(ref raw) => {
                 write!(
                     f,
                     r#"CONTEXT_AMD64
@@ -596,10 +596,10 @@ impl MinidumpContext {
                     raw.rip,
                 )?;
             }
-            MinidumpRawContext::SPARC(_) => {
+            MinidumpRawContext::Sparc(_) => {
                 unimplemented!();
             }
-            MinidumpRawContext::ARM(ref raw) => {
+            MinidumpRawContext::Arm(ref raw) => {
                 write!(
                     f,
                     r#"CONTEXT_ARM
@@ -624,7 +624,7 @@ impl MinidumpContext {
                     writeln!(f, "  float_save.extra[{:2}] = {:#x}", i, reg)?;
                 }
             }
-            MinidumpRawContext::ARM64(ref raw) => {
+            MinidumpRawContext::Arm64(ref raw) => {
                 write!(
                     f,
                     r#"CONTEXT_ARM64
@@ -648,7 +648,7 @@ impl MinidumpContext {
                     writeln!(f, "  float_save.regs[{:2}] = {:#x}", i, reg)?;
                 }
             }
-            MinidumpRawContext::OLDARM64(ref raw) => {
+            MinidumpRawContext::OldArm64(ref raw) => {
                 write!(
                     f,
                     r#"CONTEXT_ARM64
@@ -674,7 +674,7 @@ impl MinidumpContext {
                     writeln!(f, "  float_save.regs[{:2}] = {:#x}", i, reg)?;
                 }
             }
-            MinidumpRawContext::MIPS(_) => {
+            MinidumpRawContext::Mips(_) => {
                 unimplemented!();
             }
         }

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -71,7 +71,7 @@ pub enum Error {
     #[fail(display = "File not found")]
     FileNotFound,
     #[fail(display = "I/O error")]
-    IOError,
+    IoError,
     #[fail(display = "Missing minidump header")]
     MissingHeader,
     #[fail(display = "Header mismatch")]
@@ -1769,7 +1769,7 @@ impl<'a> Minidump<'a, Mmap> {
         P: AsRef<Path>,
     {
         let f = File::open(path).or(Err(Error::FileNotFound))?;
-        let mmap = unsafe { Mmap::map(&f).or(Err(Error::IOError))? };
+        let mmap = unsafe { Mmap::map(&f).or(Err(Error::IoError))? };
         Minidump::read(mmap)
     }
 }
@@ -2384,7 +2384,7 @@ mod test {
         assert_eq!(thread.raw.thread_id, 0x1234);
         let context = thread.context.expect("Should have a thread context");
         match context.raw {
-            MinidumpRawContext::AMD64(raw) => {
+            MinidumpRawContext::Amd64(raw) => {
                 assert_eq!(raw.rip, 0x1234abcd1234abcd);
                 assert_eq!(raw.rsp, 0x1000000010000000);
             }

--- a/src/synth_minidump.rs
+++ b/src/synth_minidump.rs
@@ -313,9 +313,9 @@ pub struct SimpleStream {
     pub section: Section,
 }
 
-impl Into<Section> for SimpleStream {
-    fn into(self) -> Section {
-        self.section
+impl From<SimpleStream> for Section {
+    fn from(stream: SimpleStream) -> Self {
+        stream.section
     }
 }
 
@@ -379,15 +379,15 @@ impl<T: ListItem> List<T> {
     }
 }
 
-impl<T: ListItem> Into<Section> for List<T> {
-    fn into(self) -> Section {
+impl<T: ListItem> From<List<T>> for Section {
+    fn from(list: List<T>) -> Self {
         // Finalize the entry count.
-        self.count_label.set_const(self.count as u64);
+        list.count_label.set_const(list.count as u64);
 
         // Serialize all (transitive) out-of-band data after the dense list of entry records.
-        self.section
-            .mark(&self.out_of_band.file_offset())
-            .append_section(self.out_of_band)
+        list.section
+            .mark(&list.out_of_band.file_offset())
+            .append_section(list.out_of_band)
     }
 }
 
@@ -427,9 +427,9 @@ impl<T: ListItem> ListStream<T> {
     }
 }
 
-impl<T: ListItem> Into<Section> for ListStream<T> {
-    fn into(self) -> Section {
-        self.list.into()
+impl<T: ListItem> From<ListStream<T>> for Section {
+    fn from(stream: ListStream<T>) -> Self {
+        stream.list.into()
     }
 }
 
@@ -465,9 +465,9 @@ impl DumpString {
     }
 }
 
-impl Into<Section> for DumpString {
-    fn into(self) -> Section {
-        self.section
+impl From<DumpString> for Section {
+    fn from(string: DumpString) -> Self {
+        string.section
     }
 }
 
@@ -488,9 +488,9 @@ impl DumpUtf8String {
     }
 }
 
-impl Into<Section> for DumpUtf8String {
-    fn into(self) -> Section {
-        self.section
+impl From<DumpUtf8String> for Section {
+    fn from(string: DumpUtf8String) -> Self {
+        string.section
     }
 }
 
@@ -571,13 +571,13 @@ impl Module {
 
 impl_dumpsection!(Module);
 
-impl Into<Section> for Module {
-    fn into(self) -> Section {
+impl From<Module> for Section {
+    fn from(module: Module) -> Self {
         let Module {
             section,
             cv_record,
             misc_record,
-        } = self;
+        } = module;
         section
             .cite_location(&cv_record)
             .cite_location(&misc_record)
@@ -612,9 +612,9 @@ impl Thread {
 
 impl_dumpsection!(Thread);
 
-impl Into<Section> for Thread {
-    fn into(self) -> Section {
-        self.section
+impl From<Thread> for Section {
+    fn from(thread: Thread) -> Self {
+        thread.section
     }
 }
 
@@ -639,9 +639,9 @@ impl Memory {
 
 impl_dumpsection!(Memory);
 
-impl Into<Section> for Memory {
-    fn into(self) -> Section {
-        self.section
+impl From<Memory> for Section {
+    fn from(memory: Memory) -> Self {
+        memory.section
     }
 }
 
@@ -667,14 +667,14 @@ impl MiscStream {
     }
 }
 
-impl Into<Section> for MiscStream {
-    fn into(self) -> Section {
+impl From<MiscStream> for Section {
+    fn from(stream: MiscStream) -> Self {
         let MiscStream {
             section,
             process_id,
             process_create_time,
             pad_to_size,
-        } = self;
+        } = stream;
         let flags_label = Label::new();
         let section = section.D32(&flags_label);
         let mut flags = md::MiscInfoFlags::empty();
@@ -966,9 +966,9 @@ impl Guid {
 
 // Guid does not impl DumpSections as it cannot be cited.
 
-impl Into<Section> for Guid {
-    fn into(self) -> Section {
-        self.section
+impl From<Guid> for Section {
+    fn from(guid: Guid) -> Self {
+        guid.section
     }
 }
 
@@ -1017,18 +1017,18 @@ impl CrashpadInfo {
 
 impl_dumpsection!(CrashpadInfo);
 
-impl Into<Section> for CrashpadInfo {
-    fn into(self) -> Section {
-        self.section
+impl From<CrashpadInfo> for Section {
+    fn from(info: CrashpadInfo) -> Self {
+        info.section
             .D32(md::MINIDUMP_CRASHPAD_INFO::VERSION)
-            .append_section(self.report_id)
-            .append_section(self.client_id)
-            .cite_location(&self.simple_annotations)
-            .cite_location(&self.module_list)
-            .mark(&self.simple_annotations.file_offset())
-            .append_section(self.simple_annotations)
-            .mark(&self.module_list.file_offset())
-            .append_section(self.module_list)
+            .append_section(info.report_id)
+            .append_section(info.client_id)
+            .cite_location(&info.simple_annotations)
+            .cite_location(&info.module_list)
+            .mark(&info.simple_annotations.file_offset())
+            .append_section(info.simple_annotations)
+            .mark(&info.module_list.file_offset())
+            .append_section(info.module_list)
     }
 }
 


### PR DESCRIPTION
Rust and Clippy 1.51.0 have new default warnings:

 - `clippy::from_over_into` prefers a `From` impl, which comes with a blanked `Into` impl for symmetry.
 - `clippy::upper_case_acronyms` enforces [RFC 430 naming guidelines](https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case).
 - `rustc_lint::non_fmt_panic` warns against non-format strings as first
    argument to `panic!` and related macros. In Rust 2021, this will become a hard
    error.

This includes breaking changes in the signature of some public types.