### PR TITLE
Print CrashpadInfo in minidump_dump

### DIFF
--- a/src/bin/minidump_dump.rs
+++ b/src/bin/minidump_dump.rs
@@ -57,6 +57,11 @@ fn print_minidump_dump(path: &Path) {
                 breakpad_info.print(stdout).unwrap();
             }
             // TODO: MemoryInfoList
+            match dump.get_stream::<MinidumpCrashpadInfo>() {
+                Ok(crashpad_info) => crashpad_info.print(stdout).unwrap(),
+                Err(Error::StreamNotFound) => (),
+                Err(_) => write!(stdout, "MinidumpCrashpadInfo cannot print invalid data").unwrap(),
+            }
             for &(stream, name) in streams!(
                 LinuxCmdLine,
                 LinuxEnviron,


### PR DESCRIPTION
Implements support for `MinidumpCrashpadInfo` in `minidump_dump`, mostly
equivalent to Breakpad's reference implementation. Breakpad does not
support annotation objects, which we print in a similar fashion.

This is the first time we have to interpret and print the `GUID` type.
Note that the interpretation of these GUIDs is endianness dependent,
which means that byte order of the first three fields is inverted for
little-endian _Minidumps_ independent of the host endianness.