### PR TITLE
Print out all of the MISC_INFO fields

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -1425,6 +1425,7 @@ pub struct XSTATE_CONFIG_FEATURE_MSC_INFO {
 
 /// Several known entries in `XSTATE_CONFIG_FEATURE_MSC_INFO.features`.
 #[repr(usize)]
+#[derive(Debug)]
 pub enum XStateFeatureIndex {
     LEGACY_FLOATING_POINT = 0,
     LEGACY_SSE = 1,
@@ -1436,6 +1437,25 @@ pub enum XStateFeatureIndex {
     ACK512_ZMM = 7,
     XSTATE_IPT = 8,
     XSTATE_LWP = 62,
+}
+
+impl XStateFeatureIndex {
+    pub fn from_index(idx: usize) -> Option<Self> {
+        use XStateFeatureIndex::*;
+        match idx {
+            0 => Some(LEGACY_FLOATING_POINT),
+            1 => Some(LEGACY_SSE),
+            2 => Some(GSSE_AND_AVX),
+            3 => Some(MPX_BNDREGS),
+            4 => Some(MPX_BNDCSR),
+            5 => Some(AVX512_KMASK),
+            6 => Some(AVX512_ZMM_H),
+            7 => Some(ACK512_ZMM),
+            8 => Some(XSTATE_IPT),
+            62 => Some(XSTATE_LWP),
+            _ => None,
+        }
+    }
 }
 
 bitflags! {

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -193,9 +193,10 @@ pub struct MinidumpMemory<'a> {
 #[allow(clippy::large_enum_variant)]
 pub enum RawMiscInfo {
     MiscInfo(md::MINIDUMP_MISC_INFO),
-    MiscInfo2(md::MINIDUMP_MISC_INFO2),
-    MiscInfo3(md::MINIDUMP_MISC_INFO3),
-    MiscInfo4(md::MINIDUMP_MISC_INFO4),
+    MiscInfo2(md::MINIDUMP_MISC_INFO_2),
+    MiscInfo3(md::MINIDUMP_MISC_INFO_3),
+    MiscInfo4(md::MINIDUMP_MISC_INFO_4),
+    MiscInfo5(md::MINIDUMP_MISC_INFO_5),
 }
 
 /// Miscellaneous information about the process that wrote the minidump.
@@ -1223,11 +1224,11 @@ macro_rules! misc_accessors {
         }
     };
     (1: $name:ident -> $t:ty, $($rest:tt)*) => {
-        misc_accessors!(@defnoflag $name $t [MiscInfo MiscInfo2 MiscInfo3 MiscInfo4]);
+        misc_accessors!(@defnoflag $name $t [MiscInfo MiscInfo2 MiscInfo3 MiscInfo4 MiscInfo5]);
         misc_accessors!($($rest)*);
     };
     (1: $name:ident if $flag:ident -> $t:ty, $($rest:tt)*) => {
-        misc_accessors!(@def $name $flag $t [MiscInfo MiscInfo2 MiscInfo3 MiscInfo4]);
+        misc_accessors!(@def $name $flag $t [MiscInfo MiscInfo2 MiscInfo3 MiscInfo4 MiscInfo5]);
         misc_accessors!($($rest)*);
     };
 }
@@ -1262,9 +1263,10 @@ impl<'a> MinidumpStream<'a> for MinidumpMiscInfo {
         }
 
         do_read!(
-            (md::MINIDUMP_MISC_INFO4, MiscInfo4),
-            (md::MINIDUMP_MISC_INFO3, MiscInfo3),
-            (md::MINIDUMP_MISC_INFO2, MiscInfo2),
+            (md::MINIDUMP_MISC_INFO_5, MiscInfo5),
+            (md::MINIDUMP_MISC_INFO_4, MiscInfo4),
+            (md::MINIDUMP_MISC_INFO_3, MiscInfo3),
+            (md::MINIDUMP_MISC_INFO_2, MiscInfo2),
             (md::MINIDUMP_MISC_INFO, MiscInfo),
         );
         Err(Error::StreamReadFailure)

--- a/tests/test_minidump.rs
+++ b/tests/test_minidump.rs
@@ -127,8 +127,8 @@ fn test_system_info() {
 fn test_misc_info() {
     let dump = read_test_minidump().unwrap();
     let misc_info = dump.get_stream::<MinidumpMiscInfo>().unwrap();
-    assert_eq!(misc_info.raw.process_id(), Some(3932));
-    assert_eq!(misc_info.raw.process_create_time(), Some(0x45d35f73));
+    assert_eq!(misc_info.raw.process_id(), Some(&3932));
+    assert_eq!(misc_info.raw.process_create_time(), Some(&0x45d35f73));
     assert_eq!(
         misc_info.process_create_time().unwrap(),
         Utc.ymd(2007, 2, 14).and_hms(19, 13, 55)


### PR DESCRIPTION
This includes some additional extensions to the macros that manipulate MISC_INFO fields to handle versions and simple printing cases. `misc_accessors!` has been changed to always yield an Option, and always yield references. 

Yielding references avoids very large copies for the more enormous fields, at the cost of making it slightly more awkward to use the smaller POD values. Adding special casing for reference-vs-value seemed like a needless mess, but it can be done if desired.

Making everything an Option is the result of adding support for fields which e.g. don't exist in MISC_INFO_2 but do exist in MISC_INFO_3. This is an "unnecessary" regression for precisely the first two fields of MISC_INFO which are always guaranteed to exist. Adding special casing for those two seemed like a needless mess, but it can be done if desired.

This builds on #137 (commit included until it lands).

I am a bit uncertain about how I handle SYSTEMTIME instances here. They don't seem to be "normal" SYSTEMTIME's (e.g. in the one minidump I'm testing with the year is 0). Also I just drop the day-of-the-week entry since that seems uninteresting.