### PR TITLE
gracefully fail on invalid dates

### DIFF
--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -326,15 +326,18 @@ fn format_time_t(t: u32) -> String {
 
 fn format_system_time(time: &md::SYSTEMTIME) -> String {
     // Note this drops the day_of_week field on the ground -- is that fine?
-    let date = NaiveDate::from_ymd(time.year as i32, time.month as u32, time.day as u32);
-    let time = NaiveTime::from_hms_milli(
-        time.hour as u32,
-        time.minute as u32,
-        time.second as u32,
-        time.milliseconds as u32,
-    );
-    let datetime = NaiveDateTime::new(date, time);
-    datetime.format("%Y-%m-%d %H:%M:%S:%f").to_string()
+    if let Some(date) = NaiveDate::from_ymd_opt(time.year as i32, time.month as u32, time.day as u32) {
+        let time = NaiveTime::from_hms_milli(
+            time.hour as u32,
+            time.minute as u32,
+            time.second as u32,
+            time.milliseconds as u32,
+        );
+        let datetime = NaiveDateTime::new(date, time);
+        datetime.format("%Y-%m-%d %H:%M:%S:%f").to_string()
+    } else {
+        String::new()
+    }
 }
 
 /// Produce a slice of `bytes` corresponding to the offset and size in `loc`, or an

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -338,7 +338,7 @@ fn format_system_time(time: &md::SYSTEMTIME) -> String {
         let datetime = NaiveDateTime::new(date, time);
         datetime.format("%Y-%m-%d %H:%M:%S:%f").to_string()
     } else {
-        String::new()
+        "<invalid date>".to_owned()
     }
 }
 

--- a/src/minidump.rs
+++ b/src/minidump.rs
@@ -326,7 +326,9 @@ fn format_time_t(t: u32) -> String {
 
 fn format_system_time(time: &md::SYSTEMTIME) -> String {
     // Note this drops the day_of_week field on the ground -- is that fine?
-    if let Some(date) = NaiveDate::from_ymd_opt(time.year as i32, time.month as u32, time.day as u32) {
+    if let Some(date) =
+        NaiveDate::from_ymd_opt(time.year as i32, time.month as u32, time.day as u32)
+    {
         let time = NaiveTime::from_hms_milli(
             time.hour as u32,
             time.minute as u32,


### PR DESCRIPTION
This panics on some minidumps, so instead default to the empty string if the
date is invalid.
