### PR TITLE
Beef up the minidump-processor unwinder

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -831,7 +831,7 @@ pub struct SSE_REGISTERS {
 /// An x86-64 (amd64) CPU context
 ///
 /// This struct matches the definition of `CONTEXT` in WinNT.h for x86-64.
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, SmartDefault, Clone, Pread, SizeWith)]
 pub struct CONTEXT_AMD64 {
     pub p1_home: u64,
     pub p2_home: u64,
@@ -878,7 +878,9 @@ pub struct CONTEXT_AMD64 {
     ///
     /// Callers that want to access the underlying data can use [`Pread`] to read either
     /// an [`XMM_SAVE_AREA32`] or [`SSE_REGISTERS`] struct from this raw data as appropriate.
+    #[default = "[0; 512]"]
     pub float_save: [u8; 512],
+    #[default = "[0; 26]"]
     pub vector_register: [u128; 26],
     pub vector_control: u64,
     pub debug_control: u64,

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -16,7 +16,7 @@ use minidump::*;
 /// Indicates how well the instruction pointer derived during
 /// stack walking is trusted. Since the stack walker can resort to
 /// stack scanning, it can wind up with dubious frames.
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum FrameTrust {
     /// Unknown
     None,

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -35,6 +35,7 @@ pub enum FrameTrust {
 }
 
 /// A single stack frame produced from unwinding a thread's stack.
+#[derive(Debug)]
 pub struct StackFrame {
     // The program counter location as an absolute virtual address.
     //

--- a/minidump-processor/src/stackwalker/amd64.rs
+++ b/minidump-processor/src/stackwalker/amd64.rs
@@ -1,0 +1,242 @@
+// Copyright 2015 Ted Mielczarek. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+
+// Note since x86 and Amd64 have basically the same ABI, this implementation
+// is written to largely erase the details of the two wherever possible,
+// so that it can be copied between the two with minimal changes. It's not
+// worth the effort to *actually* unify the implementations.
+
+use crate::process_state::{FrameTrust, StackFrame};
+use crate::stackwalker::unwind::Unwind;
+use minidump::format::CONTEXT_AMD64;
+use minidump::{
+    MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
+    MinidumpRawContext,
+};
+use std::collections::HashSet;
+
+type Pointer = u64;
+const POINTER_WIDTH: Pointer = 8;
+const INSTRUCTION_REGISTER: &str = "rip";
+const STACK_POINTER_REGISTER: &str = "rsp";
+const FRAME_POINTER_REGISTER: &str = "rbp";
+
+fn get_caller_by_frame_pointer(
+    ctx: &CONTEXT_AMD64,
+    valid: &MinidumpContextValidity,
+    _trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    _modules: &MinidumpModuleList,
+) -> Option<StackFrame> {
+    match valid {
+        MinidumpContextValidity::All => {}
+        MinidumpContextValidity::Some(ref which) => {
+            if !which.contains(FRAME_POINTER_REGISTER) {
+                return None;
+            }
+        }
+    }
+
+    let last_bp = ctx.rbp;
+    // Assume that the standard %bp-using x64 calling convention is in
+    // use.
+    //
+    // The typical x86 calling convention, when frame pointers are present,
+    // is for the calling procedure to use CALL, which pushes the return
+    // address onto the stack and sets the instruction pointer (%ip) to
+    // the entry point of the called routine.  The called routine then
+    // PUSHes the calling routine's frame pointer (%bp) onto the stack
+    // before copying the stack pointer (%esp) to the frame pointer (%bp).
+    // Therefore, the calling procedure's frame pointer is always available
+    // by dereferencing the called procedure's frame pointer, and the return
+    // address is always available at the memory location immediately above
+    // the address pointed to by the called procedure's frame pointer.  The
+    // calling procedure's stack pointer (%esp) is 8 higher than the value
+    // of the called procedure's frame pointer at the time the calling
+    // procedure made the CALL: 4 bytes for the return address pushed by the
+    // CALL itself, and 4 bytes for the callee's PUSH of the caller's frame
+    // pointer.
+    //
+    // %ip_new = *(%bp_old + ptr)
+    // %sp_new = %bp_old + ptr
+    // %bp_new = *(%bp_old)
+
+    let caller_ip = stack_memory.get_memory_at_address(last_bp as u64 + POINTER_WIDTH as u64)?;
+    let caller_bp = stack_memory.get_memory_at_address(last_bp as u64)?;
+    let caller_sp = last_bp + POINTER_WIDTH * 2;
+    let caller_ctx = CONTEXT_AMD64 {
+        rip: caller_ip,
+        rsp: caller_sp,
+        rbp: caller_bp,
+        ..CONTEXT_AMD64::default()
+    };
+    let mut valid = HashSet::new();
+    valid.insert(INSTRUCTION_REGISTER);
+    valid.insert(STACK_POINTER_REGISTER);
+    valid.insert(FRAME_POINTER_REGISTER);
+    let context = MinidumpContext {
+        raw: MinidumpRawContext::Amd64(caller_ctx),
+        valid: MinidumpContextValidity::Some(valid),
+    };
+    let mut frame = StackFrame::from_context(context, FrameTrust::FramePointer);
+    adjust_instruction(&mut frame, caller_ip);
+    Some(frame)
+}
+
+fn get_caller_by_cfi(
+    _ctx: &CONTEXT_AMD64,
+    _valid: &MinidumpContextValidity,
+    _trust: FrameTrust,
+    _stack_memory: &MinidumpMemory,
+    _modules: &MinidumpModuleList,
+) -> Option<StackFrame> {
+    // TODO
+    None
+}
+
+fn get_caller_by_scan(
+    ctx: &CONTEXT_AMD64,
+    valid: &MinidumpContextValidity,
+    trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    modules: &MinidumpModuleList,
+) -> Option<StackFrame> {
+    // Stack scanning is just walking from the end of the frame until we encounter
+    // a value on the stack that looks like a pointer into some code (it's an address
+    // in a range covered by one of our modules). If we find such an instruction,
+    // we assume it's an ip value that was pushed by the CALL instruction that created
+    // the current frame. The next frame is then assumed to end just before that
+    // ip value.
+    let last_bp = match valid {
+        MinidumpContextValidity::All => Some(ctx.rbp),
+        MinidumpContextValidity::Some(ref which) => {
+            if !which.contains(STACK_POINTER_REGISTER) {
+                return None;
+            }
+            if which.contains(FRAME_POINTER_REGISTER) {
+                Some(ctx.rbp)
+            } else {
+                None
+            }
+        }
+    };
+    // TODO: pointer-align this..? Does CALL push aligned ip values? Is sp aligned?
+    let last_sp = ctx.rsp;
+
+    // Number of pointer-sized values to scan through in our search.
+    let default_scan_range = 40;
+    let extended_scan_range = default_scan_range * 4;
+
+    // Breakpad devs found that the first frame of an unwind can be really messed up,
+    // and therefore benefits from a longer scan. Let's do it too.
+    let scan_range = if let FrameTrust::Context = trust {
+        extended_scan_range
+    } else {
+        default_scan_range
+    };
+
+    for i in 0..scan_range {
+        let address_of_ip = last_sp + i * POINTER_WIDTH;
+        let caller_ip = stack_memory.get_memory_at_address(address_of_ip as u64)?;
+        if instruction_seems_valid(caller_ip, modules) {
+            // ip is pushed by CALL, so sp is just address_of_ip + ptr
+            let caller_sp = address_of_ip + POINTER_WIDTH;
+
+            // Try to restore bp as well. This can be possible in two cases:
+            //
+            // 1. This function has the standard prologue that pushes bp and
+            //    sets bp = sp. If this is the case, then the current bp should be
+            //    immediately after (before in memory) address_of_ip.
+            //
+            // 2. This function does not use bp, and has just preserved it
+            //    from the caller. If this is the case, bp should be before
+            //    (after in memory) address_of_ip.
+            let mut caller_bp = None;
+
+            if let Some(last_bp) = last_bp {
+                let address_of_bp = address_of_ip - POINTER_WIDTH;
+                if last_bp == address_of_bp {
+                    let bp = stack_memory.get_memory_at_address(address_of_bp as u64)?;
+                    if bp > address_of_ip {
+                        caller_bp = Some(bp);
+                    }
+                } else if last_bp >= address_of_ip + POINTER_WIDTH {
+                    caller_bp = Some(last_bp);
+                }
+            }
+
+            let caller_ctx = CONTEXT_AMD64 {
+                rip: caller_ip,
+                rsp: caller_sp,
+                rbp: caller_bp.unwrap_or(0),
+                ..CONTEXT_AMD64::default()
+            };
+            let mut valid = HashSet::new();
+            valid.insert(INSTRUCTION_REGISTER);
+            valid.insert(STACK_POINTER_REGISTER);
+            if caller_bp.is_some() {
+                valid.insert(FRAME_POINTER_REGISTER);
+            }
+            let context = MinidumpContext {
+                raw: MinidumpRawContext::Amd64(caller_ctx),
+                valid: MinidumpContextValidity::Some(valid),
+            };
+            let mut frame = StackFrame::from_context(context, FrameTrust::Scan);
+            adjust_instruction(&mut frame, caller_ip);
+            return Some(frame);
+        }
+    }
+
+    None
+}
+
+#[allow(clippy::match_like_matches_macro)]
+fn instruction_seems_valid(instruction: Pointer, modules: &MinidumpModuleList) -> bool {
+    if let Some(_module) = modules.module_at_address(instruction as u64) {
+        // TODO: if mapped, check if this instruction actually maps to a function line
+        true
+    } else {
+        false
+    }
+}
+
+fn adjust_instruction(frame: &mut StackFrame, caller_ip: Pointer) {
+    // A caller's ip is the return address, which is the instruction
+    // after the CALL that caused us to arrive at the callee. Set
+    // the value to one less than that, so it points within the
+    // CALL instruction.
+    if caller_ip > 0 {
+        frame.instruction = caller_ip as u64 - 1;
+    }
+}
+
+impl Unwind for CONTEXT_AMD64 {
+    fn get_caller_frame(
+        &self,
+        valid: &MinidumpContextValidity,
+        trust: FrameTrust,
+        stack_memory: &Option<MinidumpMemory>,
+        modules: &MinidumpModuleList,
+    ) -> Option<StackFrame> {
+        stack_memory
+            .as_ref()
+            .and_then(|stack| {
+                get_caller_by_cfi(self, valid, trust, stack, modules)
+                    .or_else(|| get_caller_by_frame_pointer(self, valid, trust, stack, modules))
+                    .or_else(|| get_caller_by_scan(self, valid, trust, stack, modules))
+            })
+            .and_then(|frame| {
+                // Treat an instruction address of 0 as end-of-stack.
+                if frame.context.get_instruction_pointer() == 0 {
+                    return None;
+                }
+                // If the new stack pointer is at a lower address than the old,
+                // then that's clearly incorrect. Treat this as end-of-stack to
+                // enforce progress and avoid infinite loops.
+                if frame.context.get_stack_pointer() <= self.rsp {
+                    return None;
+                }
+                Some(frame)
+            })
+    }
+}

--- a/minidump-processor/src/stackwalker/amd64_unittest.rs
+++ b/minidump-processor/src/stackwalker/amd64_unittest.rs
@@ -1,0 +1,304 @@
+// Copyright 2015 Ted Mielczarek. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
+use breakpad_symbols::{SimpleSymbolSupplier, Symbolizer};
+use minidump::format::CONTEXT_AMD64;
+use minidump::*;
+use test_assembler::*;
+
+struct TestFixture {
+    pub raw: CONTEXT_AMD64,
+    pub modules: MinidumpModuleList,
+    pub symbolizer: Symbolizer,
+}
+
+impl TestFixture {
+    pub fn new() -> TestFixture {
+        TestFixture {
+            raw: CONTEXT_AMD64::default(),
+            // Give the two modules reasonable standard locations and names
+            // for tests to play with.
+            modules: MinidumpModuleList::from_modules(vec![
+                MinidumpModule::new(0x00007400c0000000, 0x10000, "module1"),
+                MinidumpModule::new(0x00007500b0000000, 0x10000, "module2"),
+            ]),
+            symbolizer: Symbolizer::new(SimpleSymbolSupplier::new(vec![])),
+        }
+    }
+
+    pub fn walk_stack(&self, stack: Section) -> CallStack {
+        let context = MinidumpContext {
+            raw: MinidumpRawContext::Amd64(self.raw.clone()),
+            valid: MinidumpContextValidity::All,
+        };
+        let base = stack.start().value().unwrap();
+        let size = stack.size();
+        let stack = stack.get_contents().unwrap();
+        let stack_memory = MinidumpMemory {
+            desc: Default::default(),
+            base_address: base,
+            size,
+            bytes: &stack,
+        };
+        walk_stack(
+            &Some(&context),
+            &Some(stack_memory),
+            &self.modules,
+            &self.symbolizer,
+        )
+    }
+}
+
+#[test]
+fn test_simple() {
+    let mut f = TestFixture::new();
+    let stack = Section::new();
+    stack.start().set_const(0x80000000);
+    // There should be no references to the stack in this walk: we don't
+    // provide any call frame information, so trying to reconstruct the
+    // context frame's caller should fail. So there's no need for us to
+    // provide stack contents.
+    f.raw.rip = 0x00007400c0000200;
+    f.raw.rbp = 0x8000000080000000;
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 1);
+    let f = &s.frames[0];
+    let m = f.module.as_ref().unwrap();
+    assert_eq!(m.code_file(), "module1");
+}
+
+#[test]
+fn test_caller_pushed_rbp() {
+    // Functions typically push their %rbp upon entry and set %rbp pointing
+    // there.  If stackwalking finds a plausible address for the next frame's
+    // %rbp directly below the return address, assume that it is indeed the
+    // next frame's %rbp.
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    let stack_start = 0x8000000080000000;
+    let return_address = 0x00007500b0000110;
+    stack.start().set_const(stack_start);
+
+    let frame0_rbp = Label::new();
+    let frame1_sp = Label::new();
+    let frame1_rbp = Label::new();
+
+    stack = stack
+        // frame 0
+        .append_repeated(16, 0) // space
+        .D64(0x00007400b0000000) // junk that's not
+        .D64(0x00007500b0000000) // a return address
+        .D64(0x00007400c0001000) // a couple of plausible addresses
+        .D64(0x00007500b000aaaa) // that are not within functions
+        .mark(&frame0_rbp)
+        .D64(&frame1_rbp) // caller-pushed %rbp
+        .D64(return_address) // actual return address
+        // frame 1
+        .mark(&frame1_sp)
+        .append_repeated(32, 0) // body of frame1
+        .mark(&frame1_rbp) // end of stack
+        .D64(0);
+
+    f.raw.rip = 0x00007400c0000200;
+    f.raw.rbp = frame0_rbp.value().unwrap();
+    f.raw.rsp = stack.start().value().unwrap();
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 2);
+
+    {
+        // To avoid reusing locals by mistake
+        let f0 = &s.frames[0];
+        assert_eq!(f0.trust, FrameTrust::Context);
+        assert_eq!(f0.context.valid, MinidumpContextValidity::All);
+        if let MinidumpRawContext::Amd64(ctx) = &f0.context.raw {
+            assert_eq!(ctx.rbp, frame0_rbp.value().unwrap());
+        } else {
+            unreachable!();
+        }
+    }
+
+    {
+        // To avoid reusing locals by mistake
+        let f1 = &s.frames[1];
+        assert_eq!(f1.trust, FrameTrust::FramePointer);
+        if let MinidumpContextValidity::Some(ref which) = f1.context.valid {
+            assert!(which.contains("rip"));
+            assert!(which.contains("rsp"));
+            assert!(which.contains("rbp"));
+        } else {
+            unreachable!();
+        }
+        if let MinidumpRawContext::Amd64(ctx) = &f1.context.raw {
+            assert_eq!(ctx.rip, return_address);
+            assert_eq!(ctx.rsp, frame1_sp.value().unwrap());
+            assert_eq!(ctx.rbp, frame1_rbp.value().unwrap());
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+#[test]
+fn test_scan_without_symbols() {
+    // When the stack walker resorts to scanning the stack,
+    // only addresses located within loaded modules are
+    // considered valid return addresses.
+    // Force scanning through three frames to ensure that the
+    // stack pointer is set properly in scan-recovered frames.
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    let stack_start = 0x8000000080000000;
+    stack.start().set_const(stack_start);
+
+    let return_address1 = 0x00007500b0000100;
+    let return_address2 = 0x00007500b0000900;
+
+    let frame1_sp = Label::new();
+    let frame2_sp = Label::new();
+    let frame1_rbp = Label::new();
+    stack = stack
+        // frame 0
+        .append_repeated(16, 0) // space
+        .D64(0x00007400b0000000) // junk that's not
+        .D64(0x00007500d0000000) // a return address
+        .D64(return_address1) // actual return address
+        // frame 1
+        .mark(&frame1_sp)
+        .append_repeated(16, 0) // space
+        .D64(0x00007400b0000000) // more junk
+        .D64(0x00007500d0000000)
+        .mark(&frame1_rbp)
+        .D64(stack_start) // This is in the right place to be
+        // a saved rbp, but it's bogus, so
+        // we shouldn't report it.
+        .D64(return_address2) // actual return address
+        // frame 2
+        .mark(&frame2_sp)
+        .append_repeated(32, 0); // end of stack
+
+    f.raw.rip = 0x00007400c0000200;
+    f.raw.rbp = frame1_rbp.value().unwrap();
+    f.raw.rsp = stack.start().value().unwrap();
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 3);
+
+    {
+        // To avoid reusing locals by mistake
+        let f0 = &s.frames[0];
+        assert_eq!(f0.trust, FrameTrust::Context);
+        assert_eq!(f0.context.valid, MinidumpContextValidity::All);
+    }
+
+    {
+        // To avoid reusing locals by mistake
+        let f1 = &s.frames[1];
+        assert_eq!(f1.trust, FrameTrust::Scan);
+        if let MinidumpContextValidity::Some(ref which) = f1.context.valid {
+            assert!(which.contains("rip"));
+            assert!(which.contains("rsp"));
+            assert!(which.contains("rbp"));
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Amd64(ctx) = &f1.context.raw {
+            assert_eq!(ctx.rip, return_address1);
+            assert_eq!(ctx.rsp, frame1_sp.value().unwrap());
+            assert_eq!(ctx.rbp, frame1_rbp.value().unwrap());
+        } else {
+            unreachable!();
+        }
+    }
+
+    {
+        // To avoid reusing locals by mistake
+        let f2 = &s.frames[2];
+        assert_eq!(f2.trust, FrameTrust::Scan);
+        if let MinidumpContextValidity::Some(ref which) = f2.context.valid {
+            assert!(which.contains("rip"));
+            assert!(which.contains("rsp"));
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Amd64(ctx) = &f2.context.raw {
+            assert_eq!(ctx.rip, return_address2);
+            assert_eq!(ctx.rsp, frame2_sp.value().unwrap());
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+/*
+// Walk a traditional frame. A traditional frame saves the caller's
+// %ebp just below the return address, and has its own %ebp pointing
+// at the saved %ebp.
+#[test]
+fn test_traditional() {
+    let mut f = TestFixture::new();
+   let frame0_rbp = Label::new();
+   let frame1_rbp = Label::new();
+   let mut stack = Section::new();
+   let stack_start = 0x80000000;
+    stack.start().set_const(stack_start);
+
+  stack = stack
+    .append_repeated(12, 0)                      // frame 0: space
+    .mark(&frame0_ebp)                  // frame 0 %ebp points here
+    .D32(&frame1_ebp)                    // frame 0: saved %ebp
+    .D32(0x40008679)                    // frame 0: return address
+    .append_repeated(8, 0)                       // frame 1: space
+    .mark(&frame1_ebp)                  // frame 1 %ebp points here
+    .D32(0)                             // frame 1: saved %ebp (stack end)
+    .D32(0);                            // frame 1: return address (stack end)
+
+  f.raw.eip = 0x4000c7a5;
+  f.raw.esp = stack.start().value().unwrap();
+  f.raw.ebp = frame0_ebp.value().unwrap();
+
+  let s = f.walk_stack(stack);
+  assert_eq!(s.frames.len(), 2);
+
+
+  {  // To avoid reusing locals by mistake
+    let f0 = &s.frames[0];
+            let f0 = &s.frames[0];
+        assert_eq!(f0.trust, FrameTrust::Context);
+        assert_eq!(f0.context.valid, MinidumpContextValidity::All);
+        assert_eq!(f0.instruction, 0x4000c7a5);
+        if let MinidumpRawContext::AMD64(ctx) = &f0.context.raw {
+            assert_eq!(ctx.rip, 0x4000c7a5);
+            assert_eq!(ctx.rsp, stack_start as u32);
+            assert_eq!(ctx.rbp, frame0_rbp.value().unwrap());
+        } else {
+            unreachable!();
+        }
+  }
+
+  {  // To avoid reusing locals by mistake
+    let f1 = &s.frames[1];
+    assert_eq!(f1.trust, FrameTrust::FramePointer);
+    if let MinidumpContextValidity::Some(ref which) = f1.context.valid {
+        assert!(which.contains("rip"));
+        assert!(which.contains("rsp"));
+        assert!(which.contains("rbp"));
+    } else {
+        unreachable!();
+    }
+    assert_eq!(f1.instruction + 1, 0x40008679);
+
+    if let MinidumpRawContext::AMD64(ctx) = &f1.context.raw {
+        assert_eq!(ctx.rip, 0x40008679);
+        assert_eq!(ctx.rbp, frame1_rbp.value().unwrap());
+    } else {
+        unreachable!();
+    }
+  }
+}
+*/

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -15,6 +15,7 @@ use self::unwind::Unwind;
 fn get_caller_frame(
     frame: &StackFrame,
     stack_memory: &Option<MinidumpMemory>,
+    modules: &MinidumpModuleList,
 ) -> Option<StackFrame> {
     match frame.context.raw {
         /*
@@ -27,7 +28,7 @@ fn get_caller_frame(
         MinidumpRawContext::MIPS(ctx) => ctx.get_caller_frame(stack_memory),
          */
         MinidumpRawContext::X86(ref ctx) => {
-            ctx.get_caller_frame(&frame.context.valid, stack_memory)
+            ctx.get_caller_frame(&frame.context.valid, frame.trust, stack_memory, modules)
         }
         _ => None,
     }
@@ -69,7 +70,7 @@ where
             fill_source_line_info(&mut frame, modules, symbol_provider);
             frames.push(frame);
             let last_frame = &frames.last().unwrap();
-            maybe_frame = get_caller_frame(last_frame, stack_memory);
+            maybe_frame = get_caller_frame(last_frame, stack_memory, modules);
         }
     } else {
         info = CallStackInfo::MissingContext;

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -3,6 +3,7 @@
 
 //! Unwind stack frames for a thread.
 
+mod amd64;
 mod unwind;
 mod x86;
 
@@ -19,7 +20,6 @@ fn get_caller_frame(
 ) -> Option<StackFrame> {
     match frame.context.raw {
         /*
-        MinidumpRawContext::AMD64(ctx) => ctx.get_caller_frame(stack_memory),
         MinidumpRawContext::ARM(ctx) => ctx.get_caller_frame(stack_memory),
         MinidumpRawContext::ARM64(ctx) => ctx.get_caller_frame(stack_memory),
         MinidumpRawContext::PPC(ctx) => ctx.get_caller_frame(stack_memory),
@@ -27,6 +27,9 @@ fn get_caller_frame(
         MinidumpRawContext::SPARC(ctx) => ctx.get_caller_frame(stack_memory),
         MinidumpRawContext::MIPS(ctx) => ctx.get_caller_frame(stack_memory),
          */
+        MinidumpRawContext::Amd64(ref ctx) => {
+            ctx.get_caller_frame(&frame.context.valid, frame.trust, stack_memory, modules)
+        }
         MinidumpRawContext::X86(ref ctx) => {
             ctx.get_caller_frame(&frame.context.valid, frame.trust, stack_memory, modules)
         }

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -82,4 +82,6 @@ where
 }
 
 #[cfg(test)]
+mod amd64_unittest;
+#[cfg(test)]
 mod x86_unittest;

--- a/minidump-processor/src/stackwalker/unwind.rs
+++ b/minidump-processor/src/stackwalker/unwind.rs
@@ -1,8 +1,8 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use crate::process_state::StackFrame;
-use minidump::{MinidumpContextValidity, MinidumpMemory};
+use crate::process_state::{FrameTrust, StackFrame};
+use minidump::{MinidumpContextValidity, MinidumpMemory, MinidumpModuleList};
 
 /// A trait for things that can unwind to a caller.
 pub trait Unwind {
@@ -10,6 +10,8 @@ pub trait Unwind {
     fn get_caller_frame(
         &self,
         valid: &MinidumpContextValidity,
+        trust: FrameTrust,
         stack_memory: &Option<MinidumpMemory>,
+        modules: &MinidumpModuleList,
     ) -> Option<StackFrame>;
 }

--- a/minidump-processor/src/stackwalker/x86.rs
+++ b/minidump-processor/src/stackwalker/x86.rs
@@ -1,36 +1,52 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
+// Note since x86 and Amd64 have basically the same ABI, this implementation
+// is written to largely erase the details of the two wherever possible,
+// so that it can be copied between the two with minimal changes. It's not
+// worth the effort to *actually* unify the implementations.
+
 use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
 use minidump::format::CONTEXT_X86;
-use minidump::{MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpRawContext};
+use minidump::{
+    MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
+    MinidumpRawContext,
+};
 use std::collections::HashSet;
+
+type Pointer = u32;
+const POINTER_WIDTH: Pointer = 4;
+const INSTRUCTION_REGISTER: &str = "eip";
+const STACK_POINTER_REGISTER: &str = "esp";
+const FRAME_POINTER_REGISTER: &str = "ebp";
 
 fn get_caller_by_frame_pointer(
     ctx: &CONTEXT_X86,
     valid: &MinidumpContextValidity,
+    _trust: FrameTrust,
     stack_memory: &MinidumpMemory,
+    _modules: &MinidumpModuleList,
 ) -> Option<StackFrame> {
-    match *valid {
+    match valid {
         MinidumpContextValidity::All => {}
         MinidumpContextValidity::Some(ref which) => {
-            if !which.contains("ebp") {
+            if !which.contains(FRAME_POINTER_REGISTER) {
                 return None;
             }
         }
     }
 
-    let last_ebp = ctx.ebp;
-    // Assume that the standard %ebp-using x86 calling convention is in
+    let last_bp = ctx.ebp;
+    // Assume that the standard %bp-using x86 calling convention is in
     // use.
     //
     // The typical x86 calling convention, when frame pointers are present,
     // is for the calling procedure to use CALL, which pushes the return
-    // address onto the stack and sets the instruction pointer (%eip) to
+    // address onto the stack and sets the instruction pointer (%ip) to
     // the entry point of the called routine.  The called routine then
-    // PUSHes the calling routine's frame pointer (%ebp) onto the stack
-    // before copying the stack pointer (%esp) to the frame pointer (%ebp).
+    // PUSHes the calling routine's frame pointer (%bp) onto the stack
+    // before copying the stack pointer (%esp) to the frame pointer (%bp).
     // Therefore, the calling procedure's frame pointer is always available
     // by dereferencing the called procedure's frame pointer, and the return
     // address is always available at the memory location immediately above
@@ -41,40 +57,156 @@ fn get_caller_by_frame_pointer(
     // CALL itself, and 4 bytes for the callee's PUSH of the caller's frame
     // pointer.
     //
-    // %eip_new = *(%ebp_old + 4)
-    // %esp_new = %ebp_old + 8
-    // %ebp_new = *(%ebp_old)
-    if let (Some(caller_eip), Some(caller_ebp)) = (
-        stack_memory.get_memory_at_address(last_ebp as u64 + 4),
-        stack_memory.get_memory_at_address(last_ebp as u64),
-    ) {
-        let caller_esp = last_ebp + 8;
-        let caller_ctx = CONTEXT_X86 {
-            eip: caller_eip,
-            esp: caller_esp,
-            ebp: caller_ebp,
-            ..CONTEXT_X86::default()
-        };
-        let mut valid = HashSet::new();
-        valid.insert("eip");
-        valid.insert("esp");
-        valid.insert("ebp");
-        let context = MinidumpContext {
-            raw: MinidumpRawContext::X86(caller_ctx),
-            valid: MinidumpContextValidity::Some(valid),
-        };
-        let mut frame = StackFrame::from_context(context, FrameTrust::FramePointer);
-        // caller_eip is the return address, which is the instruction
-        // after the CALL that caused us to arrive at the callee. Set
-        // new_frame->instruction to one less than that, so it points within the
-        // CALL instruction.
-        if caller_eip > 0 {
-            frame.instruction = (caller_eip as u64) - 1;
+    // %ip_new = *(%bp_old + ptr)
+    // %sp_new = %bp_old + ptr
+    // %bp_new = *(%bp_old)
+
+    let caller_ip = stack_memory.get_memory_at_address(last_bp as u64 + POINTER_WIDTH as u64)?;
+    let caller_bp = stack_memory.get_memory_at_address(last_bp as u64)?;
+    let caller_sp = last_bp + POINTER_WIDTH * 2;
+    let caller_ctx = CONTEXT_X86 {
+        eip: caller_ip,
+        esp: caller_sp,
+        ebp: caller_bp,
+        ..CONTEXT_X86::default()
+    };
+    let mut valid = HashSet::new();
+    valid.insert(INSTRUCTION_REGISTER);
+    valid.insert(STACK_POINTER_REGISTER);
+    valid.insert(FRAME_POINTER_REGISTER);
+    let context = MinidumpContext {
+        raw: MinidumpRawContext::X86(caller_ctx),
+        valid: MinidumpContextValidity::Some(valid),
+    };
+    let mut frame = StackFrame::from_context(context, FrameTrust::FramePointer);
+    adjust_instruction(&mut frame, caller_ip);
+    Some(frame)
+}
+
+fn get_caller_by_cfi(
+    _ctx: &CONTEXT_X86,
+    _valid: &MinidumpContextValidity,
+    _trust: FrameTrust,
+    _stack_memory: &MinidumpMemory,
+    _modules: &MinidumpModuleList,
+) -> Option<StackFrame> {
+    // TODO
+    None
+}
+
+fn get_caller_by_scan(
+    ctx: &CONTEXT_X86,
+    valid: &MinidumpContextValidity,
+    trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    modules: &MinidumpModuleList,
+) -> Option<StackFrame> {
+    // Stack scanning is just walking from the end of the frame until we encounter
+    // a value on the stack that looks like a pointer into some code (it's an address
+    // in a range covered by one of our modules). If we find such an instruction,
+    // we assume it's a ip value that was pushed by the CALL instruction that created
+    // the current frame. The next frame is then assumed to end just before that
+    // ip value.
+    let last_bp = match valid {
+        MinidumpContextValidity::All => Some(ctx.ebp),
+        MinidumpContextValidity::Some(ref which) => {
+            if !which.contains(STACK_POINTER_REGISTER) {
+                return None;
+            }
+            if which.contains(FRAME_POINTER_REGISTER) {
+                Some(ctx.ebp)
+            } else {
+                None
+            }
         }
-        Some(frame)
+    };
+    // TODO: pointer-align this..? Does CALL push aligned ip values? Is sp aligned?
+    let last_sp = ctx.esp;
+
+    // Number of pointer-sized values to scan through in our search.
+    let default_scan_range = 40;
+    let extended_scan_range = default_scan_range * 4;
+
+    // Breakpad devs found that the first frame of an unwind can be really messed up,
+    // and therefore benefits from a longer scan. Let's do it too.
+    let scan_range = if let FrameTrust::Context = trust {
+        extended_scan_range
     } else {
-        // TODO: try stack scanning
-        None
+        default_scan_range
+    };
+
+    for i in 0..scan_range {
+        let address_of_ip = last_sp + i * POINTER_WIDTH;
+        let caller_ip = stack_memory.get_memory_at_address(address_of_ip as u64)?;
+        if instruction_seems_valid(caller_ip, modules) {
+            // ip is pushed by CALL, so sp is just address_of_ip + ptr
+            let caller_sp = address_of_ip + POINTER_WIDTH;
+
+            // Try to restore bp as well. This can be possible in two cases:
+            //
+            // 1. This function has the standard prologue that pushes bp and
+            //    sets bp = sp. If this is the case, then the current bp should be
+            //    immediately after (before in memory) address_of_ip.
+            //
+            // 2. This function does not use bp, and has just preserved it
+            //    from the caller. If this is the case, bp should be before
+            //    (after in memory) address_of_ip.
+            let mut caller_bp = None;
+
+            if let Some(last_bp) = last_bp {
+                let address_of_bp = address_of_ip - POINTER_WIDTH;
+                if last_bp == address_of_bp {
+                    let bp = stack_memory.get_memory_at_address(address_of_bp as u64)?;
+                    if bp > address_of_ip {
+                        caller_bp = Some(bp);
+                    }
+                } else if last_bp >= address_of_ip + POINTER_WIDTH {
+                    caller_bp = Some(last_bp);
+                }
+            }
+
+            let caller_ctx = CONTEXT_X86 {
+                eip: caller_ip,
+                esp: caller_sp,
+                ebp: caller_bp.unwrap_or(0),
+                ..CONTEXT_X86::default()
+            };
+            let mut valid = HashSet::new();
+            valid.insert(INSTRUCTION_REGISTER);
+            valid.insert(STACK_POINTER_REGISTER);
+            if caller_bp.is_some() {
+                valid.insert(FRAME_POINTER_REGISTER);
+            }
+            let context = MinidumpContext {
+                raw: MinidumpRawContext::X86(caller_ctx),
+                valid: MinidumpContextValidity::Some(valid),
+            };
+            let mut frame = StackFrame::from_context(context, FrameTrust::Scan);
+            adjust_instruction(&mut frame, caller_ip);
+            return Some(frame);
+        }
+    }
+
+    None
+}
+
+#[allow(clippy::match_like_matches_macro)]
+fn instruction_seems_valid(instruction: Pointer, modules: &MinidumpModuleList) -> bool {
+    if let Some(_module) = modules.module_at_address(instruction as u64) {
+        // TODO: if mapped, check if this instruction actually maps to a function line
+        true
+    } else {
+        false
+    }
+}
+
+fn adjust_instruction(frame: &mut StackFrame, caller_ip: Pointer) {
+    // A caller's ip is the return address, which is the instruction
+    // after the CALL that caused us to arrive at the callee. Set
+    // the value to one less than that, so it points within the
+    // CALL instruction.
+    if caller_ip > 0 {
+        frame.instruction = caller_ip as u64 - 1;
     }
 }
 
@@ -82,10 +214,18 @@ impl Unwind for CONTEXT_X86 {
     fn get_caller_frame(
         &self,
         valid: &MinidumpContextValidity,
+        trust: FrameTrust,
         stack_memory: &Option<MinidumpMemory>,
+        modules: &MinidumpModuleList,
     ) -> Option<StackFrame> {
-        stack_memory.as_ref().and_then(|stack| {
-            get_caller_by_frame_pointer(self, valid, stack).and_then(|frame| {
+        stack_memory
+            .as_ref()
+            .and_then(|stack| {
+                get_caller_by_cfi(self, valid, trust, stack, modules)
+                    .or_else(|| get_caller_by_frame_pointer(self, valid, trust, stack, modules))
+                    .or_else(|| get_caller_by_scan(self, valid, trust, stack, modules))
+            })
+            .and_then(|frame| {
                 // Treat an instruction address of 0 as end-of-stack.
                 if frame.context.get_instruction_pointer() == 0 {
                     return None;
@@ -98,6 +238,5 @@ impl Unwind for CONTEXT_X86 {
                 }
                 Some(frame)
             })
-        })
     }
 }

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -107,3 +107,148 @@ fn test_traditional() {
         // ebp
     }
 }
+
+// Walk a traditional frame, but use a bogus %ebp value, forcing a scan
+// of the stack for something that looks like a return address.
+#[test]
+fn test_traditional_scan() {
+    let mut f = TestFixture::new();
+    let frame1_esp = Label::new();
+    let frame1_ebp = Label::new();
+    let mut stack = Section::new();
+    let stack_start = 0x80000000;
+    stack.start().set_const(stack_start);
+    stack = stack
+        // frame 0
+        .D32(0xf065dc76) // locals area:
+        .D32(0x46ee2167) // garbage that doesn't look like
+        .D32(0xbab023ec) // a return address
+        .D32(&frame1_ebp) // saved %ebp (%ebp fails to point here, forcing scan)
+        .D32(0x4000129d) // return address
+        // frame 1
+        .mark(&frame1_esp)
+        .append_repeated(8, 0) // space
+        .mark(&frame1_ebp) // %ebp points here
+        .D32(0) // saved %ebp (stack end)
+        .D32(0); // return address (stack end)
+
+    f.raw.eip = 0x4000f49d;
+    f.raw.esp = stack.start().value().unwrap() as u32;
+    // Make the frame pointer bogus, to make the stackwalker scan the stack
+    // for something that looks like a return address.
+    f.raw.ebp = 0xd43eed6e;
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 2);
+
+    {
+        // To avoid reusing locals by mistake
+        let f0 = &s.frames[0];
+        assert_eq!(f0.trust, FrameTrust::Context);
+        assert_eq!(f0.context.valid, MinidumpContextValidity::All);
+        assert_eq!(f0.instruction, 0x4000f49d);
+
+        if let MinidumpRawContext::X86(ctx) = &f0.context.raw {
+            assert_eq!(ctx.eip, 0x4000f49d);
+            assert_eq!(ctx.esp, stack_start as u32);
+            assert_eq!(ctx.ebp, 0xd43eed6e);
+        } else {
+            unreachable!();
+        }
+    }
+
+    {
+        // To avoid reusing locals by mistake
+        let f1 = &s.frames[1];
+        assert_eq!(f1.trust, FrameTrust::Scan);
+        if let MinidumpContextValidity::Some(ref which) = f1.context.valid {
+            assert!(which.contains("eip"));
+            assert!(which.contains("esp"));
+            assert!(which.contains("ebp"));
+        } else {
+            unreachable!();
+        }
+        assert_eq!(f1.instruction + 1, 0x4000129d);
+
+        if let MinidumpRawContext::X86(ctx) = &f1.context.raw {
+            assert_eq!(ctx.eip, 0x4000129d);
+            assert_eq!(ctx.esp, frame1_esp.value().unwrap() as u32);
+            assert_eq!(ctx.ebp, frame1_ebp.value().unwrap() as u32);
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+// Force scanning for a return address a long way down the stack
+#[test]
+fn test_traditional_scan_long_way() {
+    let mut f = TestFixture::new();
+    let frame1_esp = Label::new();
+    let frame1_ebp = Label::new();
+    let mut stack = Section::new();
+    let stack_start = 0x80000000;
+    stack.start().set_const(stack_start);
+
+    stack = stack
+        // frame 0
+        .D32(0xf065dc76) // locals area:
+        .D32(0x46ee2167) // garbage that doesn't look like
+        .D32(0xbab023ec) // a return address
+        .append_repeated(20 * 4, 0) // a bunch of space
+        .D32(&frame1_ebp) // saved %ebp (%ebp fails to point here, forcing scan)
+        .D32(0x4000129d) // return address
+        // frame 1
+        .mark(&frame1_esp)
+        .append_repeated(8, 0) // space
+        .mark(&frame1_ebp) // %ebp points here
+        .D32(0) // saved %ebp (stack end)
+        .D32(0); // return address (stack end)
+
+    f.raw.eip = 0x4000f49d;
+    f.raw.esp = stack.start().value().unwrap() as u32;
+    // Make the frame pointer bogus, to make the stackwalker scan the stack
+    // for something that looks like a return address.
+    f.raw.ebp = 0xd43eed6e;
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 2);
+
+    {
+        // To avoid reusing locals by mistake
+        let f0 = &s.frames[0];
+        assert_eq!(f0.trust, FrameTrust::Context);
+        assert_eq!(f0.context.valid, MinidumpContextValidity::All);
+        assert_eq!(f0.instruction, 0x4000f49d);
+
+        if let MinidumpRawContext::X86(ctx) = &f0.context.raw {
+            assert_eq!(ctx.eip, 0x4000f49d);
+            assert_eq!(ctx.esp, stack_start as u32);
+            assert_eq!(ctx.ebp, 0xd43eed6e);
+        } else {
+            unreachable!();
+        }
+    }
+
+    {
+        // To avoid reusing locals by mistake
+        let f1 = &s.frames[1];
+        assert_eq!(f1.trust, FrameTrust::Scan);
+        if let MinidumpContextValidity::Some(ref which) = f1.context.valid {
+            assert!(which.contains("eip"));
+            assert!(which.contains("esp"));
+            assert!(which.contains("ebp"));
+        } else {
+            unreachable!();
+        }
+        assert_eq!(f1.instruction + 1, 0x4000129d);
+
+        if let MinidumpRawContext::X86(ctx) = &f1.context.raw {
+            assert_eq!(ctx.eip, 0x4000129d);
+            assert_eq!(ctx.esp, frame1_esp.value().unwrap() as u32);
+            assert_eq!(ctx.ebp, frame1_ebp.value().unwrap() as u32);
+        } else {
+            unreachable!();
+        }
+    }
+}


### PR DESCRIPTION
* Fleshes out the skeleton of the unwinder a bit more
* Makes the code of the x86 implementation a bit more agnostic to 32/64-bit
* Adds a basic implementation of a scanning API for x86
* Copies the x86 implementation to provide an amd64 implementation

TODO: tests

Implementation seems to agree with the x64 firefox macos results minidump-stackwalk gets using breakpad (we're mysteriously missing CFI info on that platform, so it's good for testing non-CFI stackwalking).

e.g. "thread 1" on the following minidump demonstrates scanning https://crash-stats.mozilla.org/report/index/5f4f2fd0-a718-4730-bd23-548b00210414