### PR TITLE
Implement STACK CFI unwinding for x86/x64 (and part of STACK WIN)

### DIFF
--- a/breakpad-symbols/src/sym_file/parser.rs
+++ b/breakpad-symbols/src/sym_file/parser.rs
@@ -17,7 +17,6 @@ use std::str::FromStr;
 use minidump_common::traits::IntoRangeMapSafe;
 
 use crate::sym_file::types::*;
-use log::debug;
 
 enum Line<'a> {
     Info,
@@ -313,11 +312,9 @@ fn symbol_file_from_lines(lines: Vec<Line<'_>>) -> SymbolFile {
                 }
                 match frame_type {
                     WinFrameType::FrameData(s) => {
-                        debug!("stack_win: {:?}", s.program_string_or_base_pointer);
                         insert_win_stack_info(&mut stack_win_framedata, s);
                     }
                     WinFrameType::Fpo(s) => {
-                        debug!("stack win: {:?}", s.program_string_or_base_pointer);
                         insert_win_stack_info(&mut stack_win_fpo, s);
                     }
                     // Just ignore other types.

--- a/breakpad-symbols/src/sym_file/parser.rs
+++ b/breakpad-symbols/src/sym_file/parser.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 use minidump_common::traits::IntoRangeMapSafe;
 
 use crate::sym_file::types::*;
+use log::debug;
 
 enum Line<'a> {
     Info,
@@ -312,9 +313,11 @@ fn symbol_file_from_lines(lines: Vec<Line<'_>>) -> SymbolFile {
                 }
                 match frame_type {
                     WinFrameType::FrameData(s) => {
+                        debug!("stack_win: {:?}", s.program_string_or_base_pointer);
                         insert_win_stack_info(&mut stack_win_framedata, s);
                     }
                     WinFrameType::Fpo(s) => {
+                        debug!("stack win: {:?}", s.program_string_or_base_pointer);
                         insert_win_stack_info(&mut stack_win_fpo, s);
                     }
                     // Just ignore other types.

--- a/breakpad-symbols/src/sym_file/walker.rs
+++ b/breakpad-symbols/src/sym_file/walker.rs
@@ -1,3 +1,260 @@
+// This file implements support for breakpad's text-based STACK CFI and STACK WIN
+// unwinding instructions. These instructions are provided in "lines" corresponding
+// to all the instructions for restoring the registers at a given address in the
+// module.
+//
+// See also [the upstream breakpad docs](https://chromium.googlesource.com/breakpad/breakpad/+/master/docs/symbol_files.md).
+//
+//
+//
+// # STACK CFI
+//
+// STACK CFI lines comes in two forms:
+//
+// `STACK CFI INIT instruction_address num_bytes registers`
+//
+// `STACK CFI instruction_address registers`
+//
+//
+// A `STACK CFI INIT` line specifies how to restore registers for the given
+// range of addresses.
+//
+// Example: `STACK CFI INIT 804c4b0 40 .cfa: $esp 4 + $eip: .cfa 4 - ^`
+//
+// Arguments:
+//   * instruction_address (hex u64) is the first address in the module this line applies to
+//   * num_bytes (hex u64) is the number of bytes it (and its child STACK CFI lines) covers
+//   * registers (string) is the register restoring instructions (see the next section)
+//
+//
+// A `STACK CFI` line always follows a "parent" `STACK CFI INIT` line. It
+// updates the instructions on how to restore registers for anything within
+// the parent STACK CFI INIT's range after the given address (inclusive).
+// It only specifies rules for registers that have new instructions.
+//
+// To get the final rules for a given address, start with its `STACK CFI INIT`
+// and then apply all the applicable `STACK CFI` "diffs" in order.
+//
+// Example: `STACK CFI 804c4b1 .cfa: $esp 8 + $ebp: .cfa 8 - ^`
+//
+// Arguments:
+//   * instruction_address (hex u64) is the first address to apply these instructions
+//   * registers (string) is the new register restoring instructions (see the next section)
+//
+//
+//
+// ## STACK CFI registers
+//
+// A line's STACK CFI registers are of the form
+//
+// `REG: EXPR REG: EXPR REG: EXPR...`
+//
+// Where REG is .cfa, .ra, or $<any alphanumerics>
+// And EXPR is <anything but ":"> (see next section for details)
+//
+// Each `REG: EXPR` pair specifies how to compute the register REG for the
+// caller. There are three kinds of registers:
+//
+// * $XXX refers to an actual general-purpose register. In REG position it
+//   refers to the caller, in an EXPR it refers to the callee.
+//
+// * .cfa is the "canonical frame address" (CFA), as used in DWARF CFI. It
+//   abstractly represents the base address of the frame. On x86, x64, and
+//   ARM64 the CFA is the caller's stack pointer from *before* the call. As
+//   such on those platforms you will never see instructions to restore the
+//   frame pointer -- it must be implicitly restored from the cfa. .cfa
+//   always refers to the caller, and therefore must be computed without
+//   use of itself.
+//
+// * .ra is the "return address", which just abstractly refers to the
+//   instruction pointer/program counter. It only ever appears in REG
+//   position.
+//
+// .cfa and .ra must always have defined rules, or the STACK CFI is malformed.
+//
+// The CFA is special because its computed value can be used by every other EXPR.
+// As such it should always be computed first so that its value is available.
+// The purpose of the CFA is to cleanly handle the very common case of registers
+// saved to the stack. Every register saved this way lives at a fixed offset
+// from the start of the frame. So we can specify their rules once, and just
+// update the CFA.
+//
+// For example:
+//
+// ```text
+// STACK CFI INIT 0x10 16 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+// STACK CFI 0x11 .cfa $rsp 16 + $rax: .cfa -16 + ^
+// STACK CFI 0x12 .cfa $rsp 24 +
+// ```
+//
+// Can be understood as (pseudo-rust):
+//
+// ```rust,ignore
+// let mut cfa = 0;
+// let mut ra = None;
+// let mut caller_rax = None;
+//
+//
+// // STACK CFI INIT 0x10's original state
+// cfa = callee_rsp + 8;
+// ra = Some(|| { *(cfa - 8) });            // Defer evaluation
+//
+//
+// // STACK CFI 0x11's diff
+// if address >= 0x11 {
+//   cfa = callee_rsp + 16;
+//   caller_rax = Some(|| { *(cfa - 16) }); // Defer evaluation
+// }
+//
+//
+// // STACK CFI 0x12's diff
+// if address >= 0x12 {
+//   cfa = callee_rsp + 24;
+// }
+//
+// caller.stack_pointer = cfa;
+//
+// // Finally evaluate all other registers using the current cfa
+// caller.instruction_pointer = ra.unwrap()();
+// caller.rax = caller_rax.map(|func| func());
+// ```
+//
+//
+//
+// ## STACK CFI expressions
+//
+// STACK CFI expressions are in postfix (Reverse Polish) notation with tokens
+// separated by whitespace. e.g.
+//
+//   .cfa $rsp 3 + * ^
+//
+// Is the postfix form of
+//
+//   ^(.cfa * ($rsp + 3))
+//
+// The benefit of postfix notation is that it can be evaluated while
+// processing the input left-to-right without needing to maintain any
+// kind of parse tree.
+//
+// The only state a postfix evaluator needs to maintain is a stack of
+// computed values. When a value (see below) is encountered, it is pushed
+// onto the stack. When an operator (see below) is encountered, it can be
+// evaluated immediately by popping its inputs off the stack and pushing
+// its output onto the stack.
+//
+// If the postfix expression is valid, then at the end of the token
+// stream the stack should contain a single value, which is the result.
+//
+// For binary operators the right-hand-side (rhs) will be the first
+// value popped from the stack.
+//
+// Supported operations are:
+//
+// * `+`: Binary Add
+// * `-`: Binary Subtract
+// * `*`: Binary Multiply
+// * `/`: Binary Divide
+// * `%`: Binary Remainder
+// * `@`: Binary Align (truncate lhs to be a multiple of rhs)
+// * `^`: Unary Dereference (load from stack memory)
+//
+// Supported values are:
+//
+// * .cfa: read the CFA
+// * .undef: terminate execution, the output is explicitly unknown
+// * $<anything>: read a general purpose register from the callee's frame
+// * <a signed decimal integer>: read this integer constant (limited to i64 precision)
+//
+//
+//
+//
+//
+// # STACK WIN
+//
+// STACK WIN lines try to encode the more complex unwinding rules produced by
+// x86 Windows toolchains.
+//
+// TODO: flesh this out
+//
+// ```text
+// STACK WIN type rva code_size prologue_size epilogue_size parameter_size
+//           saved_register_size local_size max_stack_size has_program_string
+//           program_string_OR_allocates_base_pointer
+// ```
+//
+// ```
+// grand_callee_parameter_size = frame.callee.parameter_size
+// frame_size = local_size + saved_register_size + grand_callee_parameter_size
+// ```
+//
+//
+//
+// # STACK WIN frame pointer mode ("fpo")
+//
+// TODO: fill this in
+//
+// This is an older mode that just assumes a standard calling convention
+// and a known frame size. Restore eip from the stack, restore ebp from
+// the stack if necessary (allocates_base_pointer), add the frame size to
+// get the new esp.
+//
+//
+//
+// # STACK WIN expression mode ("framedata")
+//
+// STACK WIN expressions use many of the same concepts as STACK CFI, but rather
+// than using `REG: EXPR` pairs to specify outputs, it maintains a map of variables
+// whose values can be read and written by each expression.
+//
+// I personally find this easiest to understand as an extension to the STACK CFI
+// expressions, so I'll describe it in those terms:
+//
+// The supported operations add one binary operation:
+//
+// * `=`: Binary Assign (assign the rhs's integer to the lhs's variable)
+//
+// This operation requires us to have a distinction between *integers* and
+// *variables*, which the postfix evaluator's stack must hold.
+//
+// All other operators operate only on integers. If a variable is passed where
+// an integer is expected, that means the current value of the variable should
+// be used.
+//
+// "values" then become:
+//
+// * .<anything>: a variable containing some initial constants (see below)
+// * $<anything>: a variable representing a general purpose register or temporary
+// * .undef: delete the variable if this is assigned to it (like Option::None) (TODO: ?)
+// * <a signed decimal integer>: read this integer constant (limited to i64 precision)
+//
+//
+// Before evaluating a STACK WIN expression:
+//
+// * The variables `$ebp` and `$esp` should be initialized from the callee's
+//   values for those registers (error out if those are unknown). Breakpad
+//   also initializes `$ebx` if it's available, since some things want it.
+//
+// * The following constant variables should be set accordingly:
+//   * `.cbParams = parameter_size`
+//   * `.cbCalleeParams = grand_callee_parameter_size` (only for breakpad-generated exprs)
+//   * `.cbSavedRegs = saved_register_size`
+//   * `.cbLocals = local_size`
+//
+// * The variables `.raSearch` and `.raSearchStart` should be set to the address
+//   on the stack to begin scanning for a return address. This roughly corresponds
+//   to the STACK CFI's `.cfa`. Breakpad computes this with a ton of messy heuristics,
+//   but as a starting point `$esp + frame_size` is a good value.
+//
+//
+// After evaluating a STACK WIN expression:
+//
+// The caller's registers are stored in `$eip`, `$esp`, `$ebp`, `$ebx`, `$esi`,
+// and `$edi`. If those variables are undefined, then their values in the caller
+// are unknown.
+//
+// TODO: do we need to track if ebp/esp/ebx were re-written, or is it fine to
+// consider them defined if they weren't explicitly set to .undef?
+
 use super::{CfiRules, StackInfoWin, WinStackThing};
 use crate::FrameWalker;
 use log::{debug, trace};
@@ -57,12 +314,7 @@ pub fn walk_with_stack_cfi(
 }
 
 fn parse_cfi_exprs<'a>(input: &'a str, output: &mut HashMap<CfiReg<'a>, &'a str>) -> Option<()> {
-    // Parsing out "REG: EXPR REG: EXPR REG: EXPR..."
-    //
-    // Where REG is .cfa, .ra, or $<any alphanumerics>
-    // And EXPR is <anything but ":">
-    //
-    // Also note this is an ascii format so we can think chars == bytes!
+    // Note this is an ascii format so we can think chars == bytes!
 
     let base_addr = input.as_ptr() as usize;
     let mut cur_reg = None;
@@ -125,58 +377,11 @@ fn parse_cfi_exprs<'a>(input: &'a str, output: &mut HashMap<CfiReg<'a>, &'a str>
 }
 
 fn eval_cfi_expr(expr: &str, walker: &mut dyn FrameWalker, cfa: Option<u64>) -> Option<u64> {
-    // CFI expressions are in postfix (Reverse Polish) notation with tokens
-    // separated by whitespace. e.g.
-    //
-    //   .cfa $rsp 3 + * ^
-    //
-    // Is the postfix form of
-    //
-    //   ^(.cfa * ($rsp + 3))
-    //
-    // The benefit of postfix notation is that it can be evaluated while
-    // processing the input left-to-right without needing to maintain any
-    // kind of parse tree.
-    //
-    // The only state a postfix evaluator needs to maintain is a stack of
-    // computed values. When a value (see below) is encountered, it is pushed
-    // onto the stack. When an operator (see below) is encountered, it can be
-    // evaluated immediately by popping its inputs off the stack and pushing
-    // its output onto the stack.
-    //
-    // If the postfix expression is valid, then at the end of the token
-    // stream the stack should contain a single value, which is the result.
-    //
-    // For binary operators the right-hand-side (rhs) will be the first
-    // value popped from the stack.
-    //
-    // Supported operations are:
-    //
-    // * `+`: Binary Add
-    // * `-`: Binary Subtract
-    // * `*`: Binary Multiply
-    // * `/`: Binary Divide
-    // * `%`: Binary Remainder
-    // * `@`: Binary Align (truncate lhs to be a multiple of rhs)
-    // * `^`: Unary Dereference (load from stack memory)
-    //
-    // Supported values are:
-    //
-    // * .cfa: read the CFA
-    // * .undef: terminate execution, the output is explicitly unknown
-    // * $<anything>: read a general purpose register from the callee's frame
-    // * <a signed decimal integer>: read this integer constant (limited to i64 precision)
-    //
-    // STACK WIN may use a more complex extension of this that involves a map
-    // of variables that can be assigned to with a "=" operator, but that
-    // shouldn't happen with STACK CFI, so that isn't implemented here (yet).
-
     // TODO: this should be an ArrayVec or something, most exprs are simple.
     let mut stack: Vec<u64> = Vec::new();
     for token in expr.split_ascii_whitespace() {
         match token {
-            // TODO: not sure what the supported set of binary ops are,
-            // and what the overflow/sign semantics are.
+            // TODO: not sure what overflow/sign semantics are
             "+" => {
                 // Add
                 let rhs = stack.pop()?;
@@ -274,30 +479,249 @@ enum CfiReg<'a> {
     Other(&'a str),
 }
 
+fn eval_win_expr(expr: &str, info: &StackInfoWin, walker: &mut dyn FrameWalker) -> Option<()> {
+    // TODO: do a bunch of heuristics to make this more robust.
+
+    let mut vars = HashMap::new();
+
+    let callee_esp = walker.get_callee_register("esp")? as u32;
+    let callee_ebp = walker.get_callee_register("ebp")? as u32;
+    let grand_callee_param_size = walker.get_grand_callee_parameter_size();
+    let frame_size = win_frame_size(info, grand_callee_param_size);
+
+    trace!(
+        "  ...got callee registers (frame_size: {}, raSearch: {})",
+        frame_size,
+        callee_esp + frame_size
+    );
+
+    // First setup the initial variables
+    vars.insert("$esp", callee_esp);
+    vars.insert("$ebp", callee_ebp);
+    if let Some(callee_ebx) = walker.get_callee_register("ebx") {
+        vars.insert("$ebx", callee_ebx as u32);
+    }
+
+    let search_start = callee_esp + frame_size;
+
+    // Magic names from breakpad
+    vars.insert(".cbParams", info.parameter_size);
+    vars.insert(".cbCalleeParams", grand_callee_param_size);
+    vars.insert(".cbSavedRegs", info.saved_register_size);
+    vars.insert(".cbLocals", info.local_size);
+    vars.insert(".raSearch", search_start);
+    vars.insert(".raSearchStart", search_start);
+
+    // TODO: this should be an ArrayVec or something..?
+    let mut stack: Vec<WinVal> = Vec::new();
+
+    // TODO: handle the bug where "= NEXT_TOKEN" is sometimes "=NEXT_TOKEN"
+    // for some windows toolchains.
+
+    // Evaluate the expressions
+    for token in expr.split_ascii_whitespace() {
+        trace!("    ...token: {}", token);
+        match token {
+            // TODO: not sure what overflow/sign semantics are
+            "+" => {
+                // Add
+                let rhs = stack.pop()?.into_int(&vars)?;
+                let lhs = stack.pop()?.into_int(&vars)?;
+                stack.push(WinVal::Int(lhs.wrapping_add(rhs)));
+            }
+            "-" => {
+                // Subtract
+                let rhs = stack.pop()?.into_int(&vars)?;
+                let lhs = stack.pop()?.into_int(&vars)?;
+                stack.push(WinVal::Int(lhs.wrapping_sub(rhs)));
+            }
+            "*" => {
+                // Multiply
+                let rhs = stack.pop()?.into_int(&vars)?;
+                let lhs = stack.pop()?.into_int(&vars)?;
+                stack.push(WinVal::Int(lhs.wrapping_mul(rhs)));
+            }
+            "/" => {
+                // Divide
+                let rhs = stack.pop()?.into_int(&vars)?;
+                let lhs = stack.pop()?.into_int(&vars)?;
+                if rhs == 0 {
+                    // Div by 0
+                    return None;
+                }
+                stack.push(WinVal::Int(lhs.wrapping_div(rhs)));
+            }
+            "%" => {
+                // Remainder
+                let rhs = stack.pop()?.into_int(&vars)?;
+                let lhs = stack.pop()?.into_int(&vars)?;
+                if rhs == 0 {
+                    // Div by 0
+                    return None;
+                }
+                stack.push(WinVal::Int(lhs.wrapping_rem(rhs)));
+            }
+            "@" => {
+                // Align (truncate)
+                let rhs = stack.pop()?.into_int(&vars)?;
+                let lhs = stack.pop()?.into_int(&vars)?;
+
+                // NOTE: breakpad assumes rhs is a power of 2 and does
+                // lhs & (-1 ^ (rhs - 1))
+                stack.push(WinVal::Int(lhs.wrapping_div(rhs).wrapping_mul(rhs)));
+            }
+            "=" => {
+                // Assign lhs = rhs
+                let rhs = stack.pop()?;
+                let lhs = stack.pop()?.into_var()?;
+
+                if let WinVal::Undef = rhs {
+                    vars.remove(&lhs);
+                } else {
+                    vars.insert(lhs, rhs.into_int(&vars)?);
+                }
+            }
+            "^" => {
+                // Deref the value
+                let ptr = stack.pop()?.into_int(&vars)?;
+                stack.push(WinVal::Int(
+                    walker.get_register_at_address(ptr as u64)? as u32
+                ));
+            }
+            ".undef" => {
+                // This register is explicitly undefined!
+                stack.push(WinVal::Undef);
+            }
+            _ => {
+                // More complex cases
+                if token == ".undef" {
+                    stack.push(WinVal::Undef);
+                } else if token.starts_with('$') || token.starts_with('.') {
+                    // Push a register
+                    stack.push(WinVal::Var(token));
+                } else if let Ok(value) = i32::from_str(token) {
+                    // Push a constant
+                    // TODO: We do everything in wrapping arithmetic, so it's fine to squash
+                    // i32's into u32's?
+                    stack.push(WinVal::Int(value as u32));
+                } else {
+                    // Unknown expr
+                    debug!(
+                        "STACK CFI expression eval failed - unknown token: {}",
+                        token
+                    );
+                    return None;
+                }
+            }
+        }
+    }
+
+    trace!("  ...eval'd expr");
+    // panic!();
+
+    let output_regs = ["$eip", "$esp", "$ebp", "$ebx", "$esi", "$edi"];
+    for reg in &output_regs {
+        if let Some(&val) = vars.get(reg) {
+            walker.set_caller_register(&reg[1..], val as u64)?;
+        }
+    }
+
+    trace!("  ...success!");
+
+    Some(())
+}
+
+fn win_frame_size(info: &StackInfoWin, grand_callee_param_size: u32) -> u32 {
+    info.local_size + info.saved_register_size + grand_callee_param_size
+}
+
+enum WinVal<'a> {
+    Var(&'a str),
+    Int(u32),
+    Undef,
+}
+
+impl<'a> WinVal<'a> {
+    fn into_var(self) -> Option<&'a str> {
+        if let WinVal::Var(var) = self {
+            Some(var)
+        } else {
+            None
+        }
+    }
+    fn into_int(self, map: &HashMap<&'a str, u32>) -> Option<u32> {
+        match self {
+            WinVal::Var(var) => map.get(&var).cloned(),
+            WinVal::Int(int) => Some(int),
+            WinVal::Undef => None,
+        }
+    }
+}
+
+#[allow(unused_variables, unreachable_code)]
 pub fn walk_with_stack_win_framedata(
     info: &StackInfoWin,
-    _walker: &mut dyn FrameWalker,
+    walker: &mut dyn FrameWalker,
 ) -> Option<()> {
-    // TODO: implement this? I haven't found anything that uses this.
-    if let WinStackThing::ProgramString(ref string) = info.program_string_or_base_pointer {
-        debug!("STACK WIN framedata: {}", string);
+    // Temporarily disabled while I iterate on this
+    return None;
+
+    if let WinStackThing::ProgramString(ref expr) = info.program_string_or_base_pointer {
+        trace!("   ...using stack win framedata: {}", expr);
+        eval_win_expr(expr, info, walker)
     } else {
         unreachable!()
     }
-    None
 }
 
-pub fn walk_with_stack_win_fpo(info: &StackInfoWin, _walker: &mut dyn FrameWalker) -> Option<()> {
-    // TODO: implement this? I haven't found anything that uses this.
+#[allow(unused_variables, unreachable_code)]
+pub fn walk_with_stack_win_fpo(info: &StackInfoWin, walker: &mut dyn FrameWalker) -> Option<()> {
+    // Temporarily disabled while I iterate on this
+    return None;
+
     if let WinStackThing::AllocatesBasePointer(allocates_base_pointer) =
         info.program_string_or_base_pointer
     {
-        debug!(
-            "STACK WIN fpo: allocates_base_pointer: {}",
-            allocates_base_pointer
-        );
+        // TODO: do a bunch of heuristics to make this more robust.
+
+        trace!("  ...using stack win fpo");
+        let grand_callee_param_size = walker.get_grand_callee_parameter_size();
+        let frame_size = win_frame_size(info, grand_callee_param_size) as u64;
+
+        let callee_esp = walker.get_callee_register("esp")?;
+        trace!("  ...got callee esp");
+
+        let eip_address = callee_esp + frame_size;
+        let caller_eip = walker.get_register_at_address(eip_address)?;
+        let caller_esp = callee_esp + frame_size + 4;
+
+        trace!("  ...computed caller eip/esp");
+
+        let caller_ebp = if allocates_base_pointer {
+            let ebp_address =
+                callee_esp + grand_callee_param_size as u64 + info.saved_register_size as u64 - 8;
+            walker.get_register_at_address(ebp_address)?
+        } else {
+            // Per Breakpad: We also propagate %ebx through, as it is commonly unmodifed after
+            // calling simple forwarding functions in ntdll (that are this non-EBP
+            // using type). It's not clear that this is always correct, but it is
+            // important for some functions to get a correct walk.
+            if let Some(callee_ebx) = walker.get_callee_register("ebx") {
+                walker.set_caller_register("ebx", callee_ebx)?;
+            }
+
+            walker.get_callee_register("ebp")?
+        };
+        trace!("  ...computed caller ebp");
+
+        walker.set_caller_register("eip", caller_eip)?;
+        walker.set_caller_register("esp", caller_esp)?;
+        walker.set_caller_register("ebp", caller_ebp)?;
+
+        trace!("  ...success!");
+
+        Some(())
     } else {
         unreachable!()
     }
-    None
 }

--- a/breakpad-symbols/src/sym_file/walker.rs
+++ b/breakpad-symbols/src/sym_file/walker.rs
@@ -1,0 +1,303 @@
+use super::{CfiRules, StackInfoWin, WinStackThing};
+use crate::FrameWalker;
+use log::{debug, trace};
+use std::collections::HashMap;
+use std::str::FromStr;
+
+pub fn walk_with_stack_cfi(
+    init: &CfiRules,
+    additional: &[CfiRules],
+    walker: &mut dyn FrameWalker,
+) -> Option<()> {
+    trace!("  ...got cfi");
+    trace!("    {}", init.rules);
+    for line in additional {
+        trace!("    {}", line.rules);
+    }
+
+    // First we must collect up all the `REG: EXPR` pairs in these lines.
+    // If a REG occurs twice, we prefer the one that comes later. This allows
+    // STACK CFI records to apply incremental updates to the instructions.
+    let mut exprs = HashMap::new();
+    parse_cfi_exprs(&init.rules, &mut exprs)?;
+    for line in additional {
+        parse_cfi_exprs(&line.rules, &mut exprs)?;
+    }
+    trace!("  ...parsed exprs");
+    trace!("    {:?}", exprs);
+
+    // These two are special and *must* always be present
+    let cfa_expr = exprs.remove(&CfiReg::Cfa)?;
+    let ra_expr = exprs.remove(&CfiReg::Ra)?;
+    trace!("  ...had cfa and ra");
+
+    // Evaluating the CFA cannot itself use the CFA
+    let cfa = eval_cfi_expr(cfa_expr, walker, None)?;
+    let ra = eval_cfi_expr(ra_expr, walker, Some(cfa))?;
+    trace!("  ...eval'd cfa and ra");
+
+    walker.set_cfa(cfa)?;
+    walker.set_ra(ra)?;
+
+    for (reg, expr) in exprs {
+        if let CfiReg::Other(reg) = reg {
+            // If this eval fails, just don't emit this particular register
+            // and keep going on. It's fine to lose some general purpose regs.
+            eval_cfi_expr(expr, walker, Some(cfa))
+                .and_then(|val| walker.set_caller_register(reg, val));
+        } else {
+            // All special registers should already have been removed??
+            unreachable!()
+        }
+    }
+    trace!("  ...eval'd all regs");
+    trace!("  ...success!");
+
+    Some(())
+}
+
+fn parse_cfi_exprs<'a>(input: &'a str, output: &mut HashMap<CfiReg<'a>, &'a str>) -> Option<()> {
+    // Parsing out "REG: EXPR REG: EXPR REG: EXPR..."
+    //
+    // Where REG is .cfa, .ra, or $<any alphanumerics>
+    // And EXPR is <anything but ":">
+    //
+    // Also note this is an ascii format so we can think chars == bytes!
+
+    let base_addr = input.as_ptr() as usize;
+    let mut cur_reg = None;
+    let mut expr_first: Option<&str> = None;
+    let mut expr_last: Option<&str> = None;
+    for token in input.split_ascii_whitespace() {
+        if token.ends_with(':') {
+            // This token is a "REG:", indicating the end of the previous EXPR
+            // and start of the next. If we already have an active register,
+            // then now is the time to commit it to our output.
+            if let Some(reg) = cur_reg {
+                // We compute the the expr substring by just abusing the fact that rust substrings
+                // point into the original string, so we can use map addresses in the substrings
+                // back into indices into the original string.
+                let min_addr = expr_first?.as_ptr() as usize;
+                let max_addr = expr_last?.as_ptr() as usize + expr_last?.len();
+                let expr = &input[min_addr - base_addr..max_addr - base_addr];
+
+                // Intentionally overwrite any pre-existing entries for this register,
+                // because that's how CFI records work.
+                output.insert(reg, expr);
+
+                expr_first = None;
+                expr_last = None;
+            }
+
+            cur_reg = if token == ".cfa:" {
+                Some(CfiReg::Cfa)
+            } else if token == ".ra:" {
+                Some(CfiReg::Ra)
+            } else if token.starts_with('$') {
+                Some(CfiReg::Other(&token[1..token.len() - 1]))
+            } else {
+                // Malformed register
+                debug!(
+                    "STACK CFI expression parsing failed - invalid register: {}",
+                    token
+                );
+                return None;
+            };
+        } else {
+            // This is just another part of the current EXPR, update first/last accordingly.
+            if expr_first.is_none() {
+                expr_first = Some(token);
+            }
+            expr_last = Some(token);
+        }
+    }
+
+    // Process the final rule
+    if let Some(reg) = cur_reg {
+        let min_addr = expr_first?.as_ptr() as usize;
+        let max_addr = expr_last?.as_ptr() as usize + expr_last?.len();
+        let expr = &input[min_addr - base_addr..max_addr - base_addr];
+
+        output.insert(reg, expr);
+    }
+
+    Some(())
+}
+
+fn eval_cfi_expr(expr: &str, walker: &mut dyn FrameWalker, cfa: Option<u64>) -> Option<u64> {
+    // CFI expressions are in postfix (Reverse Polish) notation with tokens
+    // separated by whitespace. e.g.
+    //
+    //   .cfa $rsp 3 + * ^
+    //
+    // Is the postfix form of
+    //
+    //   ^(.cfa * ($rsp + 3))
+    //
+    // The benefit of postfix notation is that it can be evaluated while
+    // processing the input left-to-right without needing to maintain any
+    // kind of parse tree.
+    //
+    // The only state a postfix evaluator needs to maintain is a stack of
+    // computed values. When a value (see below) is encountered, it is pushed
+    // onto the stack. When an operator (see below) is encountered, it can be
+    // evaluated immediately by popping its inputs off the stack and pushing
+    // its output onto the stack.
+    //
+    // If the postfix expression is valid, then at the end of the token
+    // stream the stack should contain a single value, which is the result.
+    //
+    // For binary operators the right-hand-side (rhs) will be the first
+    // value popped from the stack.
+    //
+    // Supported operations are:
+    //
+    // * `+`: Binary Add
+    // * `-`: Binary Subtract
+    // * `*`: Binary Multiply
+    // * `/`: Binary Divide
+    // * `%`: Binary Remainder
+    // * `@`: Binary Align (truncate lhs to be a multiple of rhs)
+    // * `^`: Unary Dereference (load from stack memory)
+    //
+    // Supported values are:
+    //
+    // * .cfa: read the CFA
+    // * .undef: terminate execution, the output is explicitly unknown
+    // * $<anything>: read a general purpose register from the callee's frame
+    // * <a signed decimal integer>: read this integer constant (limited to i64 precision)
+    //
+    // STACK WIN may use a more complex extension of this that involves a map
+    // of variables that can be assigned to with a "=" operator, but that
+    // shouldn't happen with STACK CFI, so that isn't implemented here (yet).
+
+    // TODO: this should be an ArrayVec or something, most exprs are simple.
+    let mut stack: Vec<u64> = Vec::new();
+    for token in expr.split_ascii_whitespace() {
+        match token {
+            // TODO: not sure what the supported set of binary ops are,
+            // and what the overflow/sign semantics are.
+            "+" => {
+                // Add
+                let rhs = stack.pop()?;
+                let lhs = stack.pop()?;
+                stack.push(lhs.wrapping_add(rhs));
+            }
+            "-" => {
+                // Subtract
+                let rhs = stack.pop()?;
+                let lhs = stack.pop()?;
+                stack.push(lhs.wrapping_sub(rhs));
+            }
+            "*" => {
+                // Multiply
+                let rhs = stack.pop()?;
+                let lhs = stack.pop()?;
+                stack.push(lhs.wrapping_mul(rhs));
+            }
+            "/" => {
+                // Divide
+                let rhs = stack.pop()?;
+                let lhs = stack.pop()?;
+                if rhs == 0 {
+                    // Div by 0
+                    return None;
+                }
+                stack.push(lhs.wrapping_div(rhs));
+            }
+            "%" => {
+                // Remainder
+                let rhs = stack.pop()?;
+                let lhs = stack.pop()?;
+                if rhs == 0 {
+                    // Div by 0
+                    return None;
+                }
+                stack.push(lhs.wrapping_rem(rhs));
+            }
+            "@" => {
+                // Align (truncate)
+                let rhs = stack.pop()?;
+                let lhs = stack.pop()?;
+
+                // NOTE: breakpad assumes rhs is a power of 2 and does
+                // lhs & (-1 ^ (rhs - 1))
+                stack.push(lhs.wrapping_div(rhs).wrapping_mul(rhs))
+            }
+            "^" => {
+                // Deref the value
+                let ptr = stack.pop()?;
+                stack.push(walker.get_register_at_address(ptr)?);
+            }
+            ".cfa" => {
+                // Push the CFA. Note the CFA shouldn't be used to compute
+                // itself, so this returns None if that happens.
+                stack.push(cfa?);
+            }
+            ".undef" => {
+                // This register is explicitly undefined!
+                return None;
+            }
+            _ => {
+                // More complex cases
+                if let Some((_, reg)) = token.split_once('$') {
+                    // Push a register
+                    stack.push(walker.get_callee_register(reg)?);
+                } else if let Ok(value) = i64::from_str(token) {
+                    // Push a constant
+                    // TODO: We do everything in wrapping arithmetic, so it's fine to squash
+                    // i64's into u64's?
+                    stack.push(value as u64)
+                } else {
+                    // Unknown expr
+                    debug!(
+                        "STACK CFI expression eval failed - unknown token: {}",
+                        token
+                    );
+                    return None;
+                }
+            }
+        }
+    }
+
+    if stack.len() == 1 {
+        stack.pop()
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum CfiReg<'a> {
+    Cfa,
+    Ra,
+    Other(&'a str),
+}
+
+pub fn walk_with_stack_win_framedata(
+    info: &StackInfoWin,
+    _walker: &mut dyn FrameWalker,
+) -> Option<()> {
+    // TODO: implement this? I haven't found anything that uses this.
+    if let WinStackThing::ProgramString(ref string) = info.program_string_or_base_pointer {
+        debug!("STACK WIN framedata: {}", string);
+    } else {
+        unreachable!()
+    }
+    None
+}
+
+pub fn walk_with_stack_win_fpo(info: &StackInfoWin, _walker: &mut dyn FrameWalker) -> Option<()> {
+    // TODO: implement this? I haven't found anything that uses this.
+    if let WinStackThing::AllocatesBasePointer(allocates_base_pointer) =
+        info.program_string_or_base_pointer
+    {
+        debug!(
+            "STACK WIN fpo: allocates_base_pointer: {}",
+            allocates_base_pointer
+        );
+    } else {
+        unreachable!()
+    }
+    None
+}

--- a/breakpad-symbols/src/sym_file/walker.rs
+++ b/breakpad-symbols/src/sym_file/walker.rs
@@ -83,8 +83,8 @@
 //
 // ```text
 // STACK CFI INIT 0x10 16 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-// STACK CFI 0x11 .cfa $rsp 16 + $rax: .cfa -16 + ^
-// STACK CFI 0x12 .cfa $rsp 24 +
+// STACK CFI 0x11 .cfa: $rsp 16 + $rax: .cfa -16 + ^
+// STACK CFI 0x12 .cfa: $rsp 24 +
 // ```
 //
 // Can be understood as (pseudo-rust):
@@ -254,6 +254,55 @@
 //
 // TODO: do we need to track if ebp/esp/ebx were re-written, or is it fine to
 // consider them defined if they weren't explicitly set to .undef?
+//
+// TODO: should it be an error if the stack isn't empty at the end? It's
+// arguably malformed input but also it doesn't matter since the output is
+// in the variables.
+//
+//
+//
+// ## Example STACK WIN framedata evaluation
+//
+// Here is an example of framedata for a function with the standard prologue.
+// Given the input:
+//
+// ```
+// $T0 $ebp = $eip $T0 4 + ^ = $ebp $T0 ^ = $esp $T0 8 + =
+// ```
+//
+// and initial state:
+//
+// ```
+// ebp: 16, esp: 1600
+// ```
+//
+// Then evaluation proceeds as follows:
+//
+// ```
+//   Token  |    Stack     |                       Vars
+// ---------+--------------+----------------------------------------------------
+//          |              | $ebp: 16,      $esp: 1600,
+//   $T0    | $T0          | $ebp: 16,      $esp: 1600,
+//   $ebp   | $T0 $ebp     | $ebp: 16,      $esp: 1600,
+//   =      |              | $ebp: 16,      $esp: 1600,   $T0: 16,
+//   $eip   | $eip         | $ebp: 16,      $esp: 1600,   $T0: 16,
+//   $T0    | $eip $T0     | $ebp: 16,      $esp: 1600,   $T0: 16,
+//   4      | $eip $T0 4   | $ebp: 16,      $esp: 1600,   $T0: 16,
+//   +      | $eip 20      | $ebp: 16,      $esp: 1600,   $T0: 16,
+//   ^      | $eip (*20)   | $ebp: 16,      $esp: 1600,   $T0: 16,
+//   =      |              | $ebp: 16,      $esp: 1600,   $T0: 16,   $eip: (*20)
+//   $ebp   | $ebp         | $ebp: 16,      $esp: 1600,   $T0: 16,   $eip: (*20)
+//   $T0    | $ebp $T0     | $ebp: 16,      $esp: 1600,   $T0: 16,   $eip: (*20)
+//   ^      | $ebp (*16)   | $ebp: 16,      $esp: 1600,   $T0: 16,   $eip: (*20)
+//   =      |              | $ebp: (*16),   $esp: 1600,   $T0: 16,   $eip: (*20)
+//   $esp   | $esp         | $ebp: (*16),   $esp: 1600,   $T0: 16,   $eip: (*20)
+//   $T0    | $esp $T0     | $ebp: (*16),   $esp: 1600,   $T0: 16,   $eip: (*20)
+//   8      | $esp $T0 8   | $ebp: (*16),   $esp: 1600,   $T0: 16,   $eip: (*20)
+//   +      | $esp 24      | $ebp: (*16),   $esp: 1600,   $T0: 16,   $eip: (*20)
+//   =      |              | $ebp: (*16),   $esp: 24,     $T0: 16,   $eip: (*20)
+// ```
+//
+// Giving a final output of `ebp=(*16)`, `esp=24`, `eip=(*20)`.
 
 use super::{CfiRules, StackInfoWin, WinStackThing};
 use crate::FrameWalker;
@@ -356,6 +405,9 @@ fn parse_cfi_exprs<'a>(input: &'a str, output: &mut HashMap<CfiReg<'a>, &'a str>
                 return None;
             };
         } else {
+            // First token *must* be a register!
+            cur_reg.as_ref()?;
+
             // This is just another part of the current EXPR, update first/last accordingly.
             if expr_first.is_none() {
                 expr_first = Some(token);
@@ -364,14 +416,12 @@ fn parse_cfi_exprs<'a>(input: &'a str, output: &mut HashMap<CfiReg<'a>, &'a str>
         }
     }
 
-    // Process the final rule
-    if let Some(reg) = cur_reg {
-        let min_addr = expr_first?.as_ptr() as usize;
-        let max_addr = expr_last?.as_ptr() as usize + expr_last?.len();
-        let expr = &input[min_addr - base_addr..max_addr - base_addr];
+    // Process the final rule (there must be a defined reg!)
+    let min_addr = expr_first?.as_ptr() as usize;
+    let max_addr = expr_last?.as_ptr() as usize + expr_last?.len();
+    let expr = &input[min_addr - base_addr..max_addr - base_addr];
 
-        output.insert(reg, expr);
-    }
+    output.insert(cur_reg?, expr);
 
     Some(())
 }
@@ -425,9 +475,21 @@ fn eval_cfi_expr(expr: &str, walker: &mut dyn FrameWalker, cfa: Option<u64>) -> 
                 let rhs = stack.pop()?;
                 let lhs = stack.pop()?;
 
-                // NOTE: breakpad assumes rhs is a power of 2 and does
-                // lhs & (-1 ^ (rhs - 1))
-                stack.push(lhs.wrapping_div(rhs).wrapping_mul(rhs))
+                if rhs == 0 || !rhs.is_power_of_two() {
+                    return None;
+                }
+
+                // ~Bit Magic Corner~
+                //
+                // A power of two has only one bit set (e.g. 4 is 0b100), and
+                // subtracting 1 from that gets you all 1's below that bit (e.g. 0b011).
+                // -1 is all 1's.
+                //
+                // So XORing -1 with (power_of_2 - 1) gets you all ones except
+                // for the bits lower than the power of 2. ANDing that value
+                // to a number consequently makes it a multiple of that power
+                // of two (all the bits smaller than the power are cleared).
+                stack.push(lhs & (-1i64 as u64 ^ (rhs - 1)))
             }
             "^" => {
                 // Deref the value
@@ -566,9 +628,21 @@ fn eval_win_expr(expr: &str, info: &StackInfoWin, walker: &mut dyn FrameWalker) 
                 let rhs = stack.pop()?.into_int(&vars)?;
                 let lhs = stack.pop()?.into_int(&vars)?;
 
-                // NOTE: breakpad assumes rhs is a power of 2 and does
-                // lhs & (-1 ^ (rhs - 1))
-                stack.push(WinVal::Int(lhs.wrapping_div(rhs).wrapping_mul(rhs)));
+                if rhs == 0 || !rhs.is_power_of_two() {
+                    return None;
+                }
+
+                // ~Bit Magic Corner~
+                //
+                // A power of two has only one bit set (e.g. 4 is 0b100), and
+                // subtracting 1 from that gets you all 1's below that bit (e.g. 0b011).
+                // -1 is all 1's.
+                //
+                // So XORing -1 with (power_of_2 - 1) gets you all ones except
+                // for the bits lower than the power of 2. ANDing that value
+                // to a number consequently makes it a multiple of that power
+                // of two (all the bits smaller than the power are cleared).
+                stack.push(WinVal::Int(lhs & (-1i32 as u32 ^ (rhs - 1))));
             }
             "=" => {
                 // Assign lhs = rhs
@@ -723,5 +797,727 @@ pub fn walk_with_stack_win_fpo(info: &StackInfoWin, walker: &mut dyn FrameWalker
         Some(())
     } else {
         unreachable!()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::types::{CfiRules, StackInfoWin, WinStackThing};
+    use super::{eval_win_expr, walk_with_stack_cfi};
+    use crate::FrameWalker;
+    use std::collections::HashMap;
+
+    // Eugh, need this to memoize register names to static
+    static STATIC_REGS: [&str; 12] = [
+        "cfa", "ra", "esp", "eip", "ebp", "eax", "ebx", "rsp", "rip", "rbp", "rax", "rbx",
+    ];
+
+    struct TestFrameWalker<Reg> {
+        instruction: Reg,
+        grand_callee_param_size: u32,
+        callee_regs: HashMap<&'static str, Reg>,
+        caller_regs: HashMap<&'static str, Reg>,
+        stack: Vec<u8>,
+    }
+
+    trait Int {
+        const BYTES: usize;
+        fn from_bytes(bytes: &[u8]) -> Self;
+        fn into_u64(self) -> u64;
+        fn from_u64(val: u64) -> Self;
+    }
+    impl Int for u32 {
+        const BYTES: usize = 4;
+        fn from_bytes(bytes: &[u8]) -> Self {
+            let mut buf = [0; Self::BYTES];
+            buf.copy_from_slice(bytes);
+            u32::from_le_bytes(buf)
+        }
+        fn into_u64(self) -> u64 {
+            self as u64
+        }
+        fn from_u64(val: u64) -> Self {
+            val as u32
+        }
+    }
+    impl Int for u64 {
+        const BYTES: usize = 8;
+        fn from_bytes(bytes: &[u8]) -> Self {
+            let mut buf = [0; Self::BYTES];
+            buf.copy_from_slice(bytes);
+            u64::from_le_bytes(buf)
+        }
+        fn into_u64(self) -> u64 {
+            self
+        }
+        fn from_u64(val: u64) -> Self {
+            val
+        }
+    }
+
+    impl<Reg: Int + Copy> FrameWalker for TestFrameWalker<Reg> {
+        fn get_instruction(&self) -> u64 {
+            self.instruction.into_u64()
+        }
+        fn get_grand_callee_parameter_size(&self) -> u32 {
+            self.grand_callee_param_size
+        }
+        /// Get a register-sized value stored at this address.
+        fn get_register_at_address(&self, address: u64) -> Option<u64> {
+            let addr = address as usize;
+            self.stack
+                .get(addr..addr + Reg::BYTES)
+                .map(|slice| Reg::from_bytes(slice).into_u64())
+        }
+        /// Get the value of a register from the callee's frame.
+        fn get_callee_register(&self, name: &str) -> Option<u64> {
+            self.callee_regs.get(name).map(|val| val.into_u64())
+        }
+        /// Set the value of a register for the caller's frame.
+        fn set_caller_register(&mut self, name: &str, val: u64) -> Option<()> {
+            STATIC_REGS.iter().position(|&reg| reg == name).map(|idx| {
+                let memoized_reg = STATIC_REGS[idx];
+                self.caller_regs.insert(memoized_reg, Reg::from_u64(val));
+            })
+        }
+        /// Set whatever registers in the caller should be set based on the cfa (e.g. rsp).
+        fn set_cfa(&mut self, val: u64) -> Option<()> {
+            self.caller_regs.insert("cfa", Reg::from_u64(val));
+            Some(())
+        }
+        /// Set whatever registers in the caller should be set based on the return address (e.g. rip).
+        fn set_ra(&mut self, val: u64) -> Option<()> {
+            self.caller_regs.insert("ra", Reg::from_u64(val));
+            Some(())
+        }
+    }
+
+    impl<Reg: Int + Copy> TestFrameWalker<Reg> {
+        fn new(stack: Vec<u8>, callee_regs: HashMap<&'static str, Reg>) -> Self {
+            TestFrameWalker {
+                stack,
+                callee_regs,
+                caller_regs: HashMap::new(),
+
+                // Arbitrary values
+                instruction: Reg::from_u64(0xF1CEFA32),
+                grand_callee_param_size: 4,
+            }
+        }
+    }
+
+    /// Arbitrary default values in case needed.
+    fn whatever_win_info() -> StackInfoWin {
+        StackInfoWin {
+            address: 0xFEA4A123,
+            size: 16,
+            prologue_size: 4,
+            epilogue_size: 8,
+            parameter_size: 16,
+            saved_register_size: 12,
+            local_size: 24,
+            max_stack_size: 64,
+            program_string_or_base_pointer: WinStackThing::AllocatesBasePointer(false),
+        }
+    }
+
+    fn build_cfi_rules(init: &str, additional: &[&str]) -> (CfiRules, Vec<CfiRules>) {
+        let init = CfiRules {
+            address: 0,
+            rules: init.to_string(),
+        };
+        let additional = additional
+            .iter()
+            .enumerate()
+            .map(|(idx, rules)| CfiRules {
+                address: idx as u64 + 1,
+                rules: rules.to_string(),
+            })
+            .collect::<Vec<_>>();
+
+        (init, additional)
+    }
+
+    #[test]
+    fn test_stack_win_doc_example() {
+        // Final output of `ebp=(*16)`, `esp=24`, `eip=(*20)`.
+        let expr = "$T0 $ebp = $eip $T0 4 + ^ = $ebp $T0 ^ = $esp $T0 8 + =";
+        let input = vec![("ebp", 16u32), ("esp", 1600)].into_iter().collect();
+        let mut stack = vec![0; 1600];
+
+        const FINAL_EBP: u32 = 0xFA1EF2E6;
+        const FINAL_EIP: u32 = 0xB3EF04CE;
+
+        stack[16..20].copy_from_slice(&FINAL_EBP.to_le_bytes());
+        stack[20..24].copy_from_slice(&FINAL_EIP.to_le_bytes());
+
+        let mut walker = TestFrameWalker::new(stack, input);
+        let info = whatever_win_info();
+
+        eval_win_expr(expr, &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 3);
+        assert_eq!(walker.caller_regs["esp"], 24);
+        assert_eq!(walker.caller_regs["ebp"], FINAL_EBP);
+        assert_eq!(walker.caller_regs["eip"], FINAL_EIP);
+    }
+
+    #[test]
+    fn test_stack_win_ops() {
+        // Making sure all the operators do what they should.
+        let input = vec![("esp", 32u32), ("ebp", 1600)].into_iter().collect();
+        let stack = vec![0; 1600];
+
+        let mut walker = TestFrameWalker::new(stack, input);
+        let info = whatever_win_info();
+
+        // Addition!
+        walker.caller_regs.clear();
+        eval_win_expr("$esp 1 2 + = $ebp -4 0 + =", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 3);
+        assert_eq!(walker.caller_regs["ebp"], -4i32 as u32);
+
+        // Subtraction!
+        walker.caller_regs.clear();
+        eval_win_expr("$esp 5 3 - = $ebp -4 2 - =", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 2);
+        assert_eq!(walker.caller_regs["ebp"], -6i32 as u32);
+
+        // Multiplication!
+        walker.caller_regs.clear();
+        eval_win_expr("$esp 5 3 * = $ebp -4 2 * =", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 15);
+        assert_eq!(walker.caller_regs["ebp"], -8i32 as u32);
+
+        // Division!
+        walker.caller_regs.clear();
+        eval_win_expr("$esp 5 3 / = $ebp -4 2 / =", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 1);
+        // TODO: oh no this fails, u64/u32 mismatches ARE a problem...
+        // assert_eq!(walker.caller_regs["ebp"], -2i32 as u32);
+
+        // Modulo!
+        walker.caller_regs.clear();
+        eval_win_expr("$esp  5 3 %  = $ebp -1 2 % = ", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 2);
+        assert_eq!(walker.caller_regs["ebp"], 1);
+
+        // Align!
+        walker.caller_regs.clear();
+        eval_win_expr("$esp  8 16 @ = $ebp 161 8 @ = ", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 0);
+        assert_eq!(walker.caller_regs["ebp"], 160);
+
+        // Operator Errors - Missing Inputs
+
+        // + missing args
+        assert!(eval_win_expr("1 + ", &info, &mut walker).is_none());
+
+        // - missing args
+        assert!(eval_win_expr("1 -", &info, &mut walker).is_none());
+
+        // * missing args
+        assert!(eval_win_expr("1 *", &info, &mut walker).is_none());
+
+        // / missing args
+        assert!(eval_win_expr("1 /", &info, &mut walker).is_none());
+
+        // % missing args
+        assert!(eval_win_expr("1 %", &info, &mut walker).is_none());
+
+        // @ missing args
+        assert!(eval_win_expr("1 @", &info, &mut walker).is_none());
+
+        // ^ missing arg
+        assert!(eval_win_expr("^", &info, &mut walker).is_none());
+
+        // Operator Errors - Invalid Inputs
+
+        // / by 0
+        assert!(eval_win_expr("$esp 1 0 / = $ebp 1 =", &info, &mut walker).is_none());
+
+        // % by 0
+        assert!(eval_win_expr("$esp 1 0 % = $ebp 1 =", &info, &mut walker).is_none());
+
+        // @ by 0
+        assert!(eval_win_expr("$esp 1 0 @ = $ebp 1 =", &info, &mut walker).is_none());
+
+        // @ not power of 2
+        assert!(eval_win_expr("$esp 1 3 @ = $ebp 1 =", &info, &mut walker).is_none());
+    }
+
+    #[test]
+    fn test_stack_win_corners() {
+        // Making sure all the operators do what they should.
+        let input = vec![("esp", 32u32), ("ebp", 1600)].into_iter().collect();
+        let stack = vec![0; 1600];
+
+        let mut walker = TestFrameWalker::new(stack, input);
+        let info = whatever_win_info();
+
+        // Empty expression is ok, just forward through registers
+        walker.caller_regs.clear();
+        eval_win_expr("", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 32);
+        assert_eq!(walker.caller_regs["ebp"], 1600);
+
+        // Undef works
+        walker.caller_regs.clear();
+        eval_win_expr("$esp .undef = $ebp .undef =", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 0);
+
+        // Idempotent works
+        walker.caller_regs.clear();
+        eval_win_expr("$esp $esp = $ebp $ebp =", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 32);
+        assert_eq!(walker.caller_regs["ebp"], 1600);
+
+        // Trailing garbage in the stack is ok
+        walker.caller_regs.clear();
+        eval_win_expr("$esp 1 = $ebp 2 = 3 4 5", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 1);
+        assert_eq!(walker.caller_regs["ebp"], 2);
+
+        // Trailing garbage in the stack is ok (with variables)
+        walker.caller_regs.clear();
+        eval_win_expr("$esp 1 = $ebp 2 = 3 4 5 $esp $eax", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 1);
+        assert_eq!(walker.caller_regs["ebp"], 2);
+
+        // Temporaries don't get assigned to output
+        walker.caller_regs.clear();
+        eval_win_expr("$t0 1 = $esp $t0 5 + = $ebp 2 =", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 6);
+        assert_eq!(walker.caller_regs["ebp"], 2);
+
+        // Variables can be assigned after they are pushed
+        walker.caller_regs.clear();
+        eval_win_expr("$esp  $T0 $T0 2 = = $ebp 3 =", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 2);
+        assert_eq!(walker.caller_regs["ebp"], 3);
+    }
+
+    #[test]
+    fn test_stack_win_errors() {
+        // Making sure all the operators do what they should.
+        let input = vec![("esp", 32u32), ("ebp", 1600)].into_iter().collect();
+        let stack = vec![0; 1600];
+
+        let mut walker = TestFrameWalker::new(stack, input);
+        let info = whatever_win_info();
+
+        // Deref out of bounds
+        assert!(eval_win_expr("$esp 2000 ^ =", &info, &mut walker).is_none());
+
+        // Reading undefined value
+        assert!(eval_win_expr("$esp $kitties =", &info, &mut walker).is_none());
+
+        // Reading value before defined
+        assert!(eval_win_expr("$esp $kitties = $kitties 1 =", &info, &mut walker).is_none());
+
+        // Reading deleted value
+        assert!(eval_win_expr("$esp .undef = $ebp $esp =", &info, &mut walker).is_none());
+
+        // Assigning value to value
+        assert!(eval_win_expr("0 2 =", &info, &mut walker).is_none());
+
+        // Assigning variable to value
+        assert!(eval_win_expr("0 $esp =", &info, &mut walker).is_none());
+
+        // Variables must start with $ or .
+        assert!(eval_win_expr("esp 2 = ebp 3 =", &info, &mut walker).is_none());
+    }
+
+    #[test]
+    #[ignore]
+    fn test_stack_win_equal_fixup() {
+        // Bug in old windows toolchains that sometimes cause = to lose
+        // its trailing space. Although we would ideally reject this, we're
+        // at the mercy of what toolchains emit :(
+
+        // TODO: this test currently fails! (hence the #[ignore])
+
+        let input = vec![("esp", 32u32), ("ebp", 1600)].into_iter().collect();
+        let stack = vec![0; 1600];
+
+        let mut walker = TestFrameWalker::new(stack, input);
+        let info = whatever_win_info();
+
+        eval_win_expr("$esp 1 =$ebp 2 =", &info, &mut walker).unwrap();
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 1);
+        assert_eq!(walker.caller_regs["ebp"], 2);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_stack_win_negative_division() {
+        // Negative division issues
+
+        // TODO: this test currently fails! (hence the #[ignore])
+
+        let input = vec![("esp", 32u32), ("ebp", 1600)].into_iter().collect();
+        let stack = vec![0; 1600];
+
+        let mut walker = TestFrameWalker::new(stack, input);
+        let info = whatever_win_info();
+
+        // Division!
+        walker.caller_regs.clear();
+        eval_win_expr("$esp 5 3 / = $ebp -4 2 / =", &info, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["esp"], 1);
+        assert_eq!(walker.caller_regs["ebp"], -2i32 as u32);
+    }
+
+    #[test]
+    fn test_stack_cfi_doc_example() {
+        // Final output of:
+        //
+        // cfa = callee_rsp + 24
+        // ra = *(cfa - 8)
+        // rax = *(cfa - 16)
+
+        let init = ".cfa: $rsp 8 + .ra: .cfa -8 + ^";
+        let additional = &[".cfa: $rsp 16 + $rax: .cfa -16 + ^", ".cfa: $rsp 24 +"];
+        let input = vec![("rsp", 32u64), ("rip", 1600)].into_iter().collect();
+        let mut stack = vec![0; 1600];
+
+        const FINAL_CFA: usize = 32 + 24;
+        const FINAL_RA: u64 = 0xFA1E_F2E6_A2DF_2B68;
+        const FINAL_RAX: u64 = 0xB3EF_04CE_4321_FE2A;
+
+        stack[FINAL_CFA - 8..FINAL_CFA].copy_from_slice(&FINAL_RA.to_le_bytes());
+        stack[FINAL_CFA - 16..FINAL_CFA - 8].copy_from_slice(&FINAL_RAX.to_le_bytes());
+
+        let mut walker = TestFrameWalker::new(stack, input);
+        let (init, additional) = build_cfi_rules(init, additional);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 3);
+        assert_eq!(walker.caller_regs["cfa"], FINAL_CFA as u64);
+        assert_eq!(walker.caller_regs["ra"], FINAL_RA);
+        assert_eq!(walker.caller_regs["rax"], FINAL_RAX);
+    }
+
+    #[test]
+    fn test_stack_cfi_ops() {
+        // Making sure all the operators do what they should, using 32-bit
+        // to stress truncation issues from u64 <-> u32 mapping of the
+        // abstraction.
+        let input = vec![("esp", 32u32), ("eip", 1600)].into_iter().collect();
+        let stack = vec![0; 1600];
+
+        let mut walker = TestFrameWalker::new(stack, input);
+
+        // Addition!
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 1 2 + .ra: -4 0 +", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["cfa"], 3);
+        assert_eq!(walker.caller_regs["ra"], -4i32 as u32);
+
+        // Subtraction!
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 5 3 - .ra: -4 2 -", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["cfa"], 2);
+        assert_eq!(walker.caller_regs["ra"], -6i32 as u32);
+
+        // Multiplication!
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 5 3 * .ra: -4 2 *", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["cfa"], 15);
+        assert_eq!(walker.caller_regs["ra"], -8i32 as u32);
+
+        // Division!
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 5 3 / .ra: -4 2 /", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["cfa"], 1);
+        assert_eq!(walker.caller_regs["ra"], -2i32 as u32);
+
+        // Modulo!
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 5 3 % .ra: -1 2 %", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["cfa"], 2);
+        assert_eq!(walker.caller_regs["ra"], 1);
+
+        // Align!
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 8 16 @ .ra: 161 8 @", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["cfa"], 0);
+        assert_eq!(walker.caller_regs["ra"], 160);
+
+        // Operator Errors - Missing Inputs
+
+        // + missing args
+        let (init, additional) = build_cfi_rules(".cfa: 1 + .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // - missing args
+        let (init, additional) = build_cfi_rules(".cfa: 1 - .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // * missing args
+        let (init, additional) = build_cfi_rules(".cfa: 1 * .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // / missing args
+        let (init, additional) = build_cfi_rules(".cfa: 1 / .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // % missing args
+        let (init, additional) = build_cfi_rules(".cfa: 1 % .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // @ missing args
+        let (init, additional) = build_cfi_rules(".cfa: 1 @ .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // ^ missing arg
+        let (init, additional) = build_cfi_rules(".cfa: ^ .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Operator Errors - Invalid Inputs
+
+        // / by 0
+        let (init, additional) = build_cfi_rules(".cfa: 1 0 / .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // % by 0
+        let (init, additional) = build_cfi_rules(".cfa: 1 0 % .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // @ by 0
+        let (init, additional) = build_cfi_rules(".cfa: 1 0 @ .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // @ not power of 2
+        let (init, additional) = build_cfi_rules(".cfa: 1 3 @ .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+    }
+
+    #[test]
+    fn test_stack_cfi_errors() {
+        // Checking various issues that we should bail on
+        let input = vec![("rsp", 32u64), ("rip", 1600)].into_iter().collect();
+        let stack = vec![0; 1600];
+
+        let mut walker = TestFrameWalker::new(stack, input);
+
+        // Basic syntax
+
+        // Missing .ra
+        let (init, additional) = build_cfi_rules(".cfa: 8 16 +", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Missing .cfa
+        let (init, additional) = build_cfi_rules(".ra: 8 16 *", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // No : at all
+        let (init, additional) = build_cfi_rules(".cfa 8 16 *", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Doesn't start with a REG
+        let (init, additional) = build_cfi_rules(".esp 8 16 * .cfa: 16 .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // .cfa has extra junk on stack
+        let (init, additional) = build_cfi_rules(".cfa: 8 12 .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // REG has empty expr (trailing)
+        let (init, additional) = build_cfi_rules(".cfa: 12 .ra: 8 $rax:", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // REG has empty expr (trailing with space)
+        let (init, additional) = build_cfi_rules(".cfa: 12 .ra: 8 $rax: ", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // REG has empty expr (middle)
+        let (init, additional) = build_cfi_rules(".cfa: 12 .ra: 8 $rax: $rbx: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Make sure = operator isn't supported in this implementation
+        let (init, additional) = build_cfi_rules(".cfa: 12 .ra: $rsp $rip =", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // .cfa is undef
+        let (init, additional) = build_cfi_rules(".cfa: .undef .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // .ra is undef
+        let (init, additional) = build_cfi_rules(".cfa: 8 .ra: .undef", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Reading out of bounds
+        let (init, additional) = build_cfi_rules(".cfa: 2000 ^ .ra: 8", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Undefined .reg
+        let (init, additional) = build_cfi_rules(".cfa: 8 .ra: 8 .kitties: 16", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Trying to write to .undef
+        let (init, additional) = build_cfi_rules(".cfa: 8 .ra: 8 .undef: 16", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Reading fake $reg
+        let (init, additional) = build_cfi_rules(".cfa: 8 .ra: $kitties", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Reading real but still undefined $reg
+        let (init, additional) = build_cfi_rules(".cfa: 8 .ra: $rax", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Reading .cfa for .cfa's own value
+        let (init, additional) = build_cfi_rules(".cfa: .cfa .ra: 2", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Reading .ra for .cfa's value
+        let (init, additional) = build_cfi_rules(".cfa: .ra .ra: 2", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Reading .ra for .ra's value
+        let (init, additional) = build_cfi_rules(".cfa: 1 .ra: .ra", &[]);
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+
+        // Malformed doc example shouldn't work (found while typoing docs)
+        // Note the first .cfa in the additional lines has no `:`!
+        let (init, additional) = build_cfi_rules(
+            ".cfa: $rsp 8 + .ra: .cfa -8 + ^",
+            &[".cfa $rsp 16 + $rax: .cfa -16 + ^", ".cfa $rsp 24 +"],
+        );
+        assert!(walk_with_stack_cfi(&init, &additional, &mut walker).is_none());
+    }
+
+    #[test]
+    fn test_stack_cfi_corners() {
+        // Checking various issues that we should bail on
+        let input = vec![("rsp", 32u64), ("rip", 1600)].into_iter().collect();
+        let stack = vec![0; 1600];
+
+        let mut walker = TestFrameWalker::new(stack, input);
+
+        // Just a value for each reg (no ops to execute)
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 8 .ra: 12 $rax: 16", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 3);
+        assert_eq!(walker.caller_regs["cfa"], 8);
+        assert_eq!(walker.caller_regs["ra"], 12);
+        assert_eq!(walker.caller_regs["rax"], 16);
+
+        // Undef $REGs are ok, Undef in the middle of expr ok
+        walker.caller_regs.clear();
+        let (init, additional) =
+            build_cfi_rules(".cfa: 8 .ra: 12 $rax: .undef $rbx: 1 .undef +", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["cfa"], 8);
+        assert_eq!(walker.caller_regs["ra"], 12);
+
+        // Unknown $reg output is ok; evaluated but value discarded
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 8 .ra: 12 $kitties: 16", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["cfa"], 8);
+        assert_eq!(walker.caller_regs["ra"], 12);
+
+        // Smooshed regs are garbage but we don't validate the string so it should work
+        // the same as an unknown reg (dubious behaviour but hey let's be aware of it).
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 12 .ra: 8 $rax:$rbx: 8", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["cfa"], 12);
+        assert_eq!(walker.caller_regs["ra"], 8);
+
+        // Evaluation errors for $reg output ok; value is discarded
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 1 .ra: 8 $rax: 1 0 /", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["cfa"], 1);
+        assert_eq!(walker.caller_regs["ra"], 8);
+
+        // Duplicate records are ok (use the later one)
+        walker.caller_regs.clear();
+        let (init, additional) =
+            build_cfi_rules(".cfa: 1 .cfa: 2 .ra: 3 .ra: 4 $rax: 5 $rax: 6", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 3);
+        assert_eq!(walker.caller_regs["cfa"], 2);
+        assert_eq!(walker.caller_regs["ra"], 4);
+        assert_eq!(walker.caller_regs["rax"], 6);
+
+        // Using .cfa works fine
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 7 .ra: .cfa 1 + $rax: .cfa 2 -", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 3);
+        assert_eq!(walker.caller_regs["cfa"], 7);
+        assert_eq!(walker.caller_regs["ra"], 8);
+        assert_eq!(walker.caller_regs["rax"], 5);
+
+        // Reading .ra for $REG's value is ok; value is discarded
+        walker.caller_regs.clear();
+        let (init, additional) = build_cfi_rules(".cfa: 1 .ra: 2 $rax: .ra", &[]);
+        walk_with_stack_cfi(&init, &additional, &mut walker).unwrap();
+
+        assert_eq!(walker.caller_regs.len(), 2);
+        assert_eq!(walker.caller_regs["cfa"], 1);
+        assert_eq!(walker.caller_regs["ra"], 2);
     }
 }

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -27,6 +27,7 @@ object = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.9"
+scroll = "0.10.2"
 
 [dev-dependencies]
 test-assembler = "0.1.5"

--- a/minidump-processor/src/dwarf_symbolizer.rs
+++ b/minidump-processor/src/dwarf_symbolizer.rs
@@ -63,8 +63,9 @@ impl SymbolProvider for DwarfSymbolizer {
                     //TODO: get base address for line
                     frame.set_source_file(&source_file, line.unwrap_or(0) as u32, 0);
                     //TODO: get base address for function
+                    //TODO: get parameter size for function?
                     if let Ok(name) = func.demangle() {
-                        frame.set_function(&name, 0);
+                        frame.set_function(&name, 0, 0);
                         break;
                     }
                 }

--- a/minidump-processor/src/dwarf_symbolizer.rs
+++ b/minidump-processor/src/dwarf_symbolizer.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::File;
 
-use breakpad_symbols::FrameSymbolizer;
+use breakpad_symbols::{FrameSymbolizer, FrameWalker};
 use minidump::Module;
 
 use crate::SymbolProvider;
@@ -70,5 +70,9 @@ impl SymbolProvider for DwarfSymbolizer {
                 }
             }
         }
+    }
+    fn walk_frame(&self, _module: &dyn Module, _walker: &mut dyn FrameWalker) -> Option<()> {
+        // unimplemented
+        None
     }
 }

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -70,6 +70,10 @@ pub struct StackFrame {
     /// are not available.
     pub function_base: Option<u64>,
 
+    /// The size, in bytes, of the arguments pushed on the stack for this function.
+    /// WIN STACK unwinding needs this value to work; it's otherwise uninteresting.
+    pub parameter_size: Option<u32>,
+
     /// The source file name, may be omitted if debug symbols are not available.
     pub source_file_name: Option<String>,
 
@@ -183,6 +187,7 @@ impl StackFrame {
             module: None,
             function_name: None,
             function_base: None,
+            parameter_size: None,
             source_file_name: None,
             source_line: None,
             source_line_base: None,
@@ -202,9 +207,10 @@ impl FrameSymbolizer for StackFrame {
     fn get_instruction(&self) -> u64 {
         self.instruction
     }
-    fn set_function(&mut self, name: &str, base: u64) {
+    fn set_function(&mut self, name: &str, base: u64, parameter_size: u32) {
         self.function_name = Some(String::from(name));
         self.function_base = Some(base);
+        self.parameter_size = Some(parameter_size);
     }
     fn set_source_file(&mut self, file: &str, line: u32, base: u64) {
         self.source_file_name = Some(String::from(file));

--- a/minidump-processor/src/stackwalker/amd64.rs
+++ b/minidump-processor/src/stackwalker/amd64.rs
@@ -8,6 +8,9 @@
 
 use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
+use crate::stackwalker::CfiStackWalker;
+use crate::SymbolProvider;
+use log::trace;
 use minidump::format::CONTEXT_AMD64;
 use minidump::{
     MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
@@ -93,15 +96,51 @@ fn get_caller_by_frame_pointer(
     Some(frame)
 }
 
-fn get_caller_by_cfi(
-    _ctx: &CONTEXT_AMD64,
-    _valid: &MinidumpContextValidity,
+fn get_caller_by_cfi<P>(
+    ctx: &CONTEXT_AMD64,
+    valid: &MinidumpContextValidity,
     _trust: FrameTrust,
-    _stack_memory: &MinidumpMemory,
-    _modules: &MinidumpModuleList,
-) -> Option<StackFrame> {
-    // TODO
-    None
+    stack_memory: &MinidumpMemory,
+    modules: &MinidumpModuleList,
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
+    trace!("trying to get frame by cfi");
+    if let MinidumpContextValidity::Some(ref which) = valid {
+        if !which.contains(INSTRUCTION_REGISTER) {
+            return None;
+        }
+    }
+
+    trace!("  ...context was good");
+
+    let instruction = ctx.rip;
+    let module = modules.module_at_address(instruction as u64)?;
+
+    let mut stack_walker = CfiStackWalker {
+        instruction: instruction as u64,
+
+        callee_ctx: ctx,
+        callee_validity: valid,
+
+        caller_ctx: CONTEXT_AMD64::default(),
+        caller_validity: HashSet::new(),
+
+        stack_memory,
+    };
+
+    symbol_provider.walk_frame(module, &mut stack_walker)?;
+    let ip = stack_walker.caller_ctx.rip;
+
+    let context = MinidumpContext {
+        raw: MinidumpRawContext::Amd64(stack_walker.caller_ctx),
+        valid: MinidumpContextValidity::Some(stack_walker.caller_validity),
+    };
+    let mut frame = StackFrame::from_context(context, FrameTrust::CallFrameInfo);
+    adjust_instruction(&mut frame, ip);
+    Some(frame)
 }
 
 fn get_caller_by_scan(
@@ -265,17 +304,21 @@ fn is_non_canonical(ptr: Pointer) -> bool {
 }
 
 impl Unwind for CONTEXT_AMD64 {
-    fn get_caller_frame(
+    fn get_caller_frame<P>(
         &self,
         valid: &MinidumpContextValidity,
         trust: FrameTrust,
         stack_memory: Option<&MinidumpMemory>,
         modules: &MinidumpModuleList,
-    ) -> Option<StackFrame> {
+        symbol_provider: &P,
+    ) -> Option<StackFrame>
+    where
+        P: SymbolProvider,
+    {
         stack_memory
             .as_ref()
             .and_then(|stack| {
-                get_caller_by_cfi(self, valid, trust, stack, modules)
+                get_caller_by_cfi(self, valid, trust, stack, modules, symbol_provider)
                     .or_else(|| get_caller_by_frame_pointer(self, valid, trust, stack, modules))
                     .or_else(|| get_caller_by_scan(self, valid, trust, stack, modules))
             })

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -10,14 +10,75 @@ mod x86;
 use crate::process_state::*;
 use crate::SymbolProvider;
 use minidump::*;
+use scroll::ctx::{SizeWith, TryFromCtx};
 
 use self::unwind::Unwind;
+use breakpad_symbols::FrameWalker;
+use std::collections::HashSet;
+use std::convert::TryFrom;
 
-fn get_caller_frame(
+struct CfiStackWalker<'a, C: CpuContext> {
+    instruction: u64,
+
+    callee_ctx: &'a C,
+    callee_validity: &'a MinidumpContextValidity,
+
+    caller_ctx: C,
+    caller_validity: HashSet<&'static str>,
+
+    stack_memory: &'a MinidumpMemory<'a>,
+}
+
+impl<'a, C> FrameWalker for CfiStackWalker<'a, C>
+where
+    C: CpuContext,
+    C::Register: TryFrom<u64>,
+    u64: TryFrom<C::Register>,
+    C::Register: TryFromCtx<'a, Endian, [u8], Error = scroll::Error> + SizeWith<Endian>,
+{
+    fn get_instruction(&self) -> u64 {
+        self.instruction
+    }
+    fn get_register_at_address(&self, address: u64) -> Option<u64> {
+        let result: Option<C::Register> = self.stack_memory.get_memory_at_address(address);
+        result.and_then(|val| u64::try_from(val).ok())
+    }
+    fn get_callee_register(&self, name: &str) -> Option<u64> {
+        self.callee_ctx
+            .get_register(name, self.callee_validity)
+            .and_then(|val| u64::try_from(val).ok())
+    }
+    fn set_caller_register(&mut self, name: &str, val: u64) -> Option<()> {
+        let memoized = self.caller_ctx.memoize_register(name)?;
+        let val = C::Register::try_from(val).ok()?;
+        self.caller_validity.insert(memoized);
+        self.caller_ctx.set_register(name, val)
+    }
+    fn set_cfa(&mut self, val: u64) -> Option<()> {
+        // TODO: some things have alluded to architectures where this isn't
+        // how the CFA should be handled, but I don't know what they are.
+        let stack_pointer_reg = self.caller_ctx.stack_pointer_register_name();
+        let val = C::Register::try_from(val).ok()?;
+        self.caller_validity.insert(stack_pointer_reg);
+        self.caller_ctx.set_register(stack_pointer_reg, val)
+    }
+    fn set_ra(&mut self, val: u64) -> Option<()> {
+        let instruction_pointer_reg = self.caller_ctx.instruction_pointer_register_name();
+        let val = C::Register::try_from(val).ok()?;
+        self.caller_validity.insert(instruction_pointer_reg);
+        self.caller_ctx.set_register(instruction_pointer_reg, val)
+    }
+}
+
+fn get_caller_frame<P>(
     frame: &StackFrame,
     stack_memory: Option<&MinidumpMemory>,
     modules: &MinidumpModuleList,
-) -> Option<StackFrame> {
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
     match frame.context.raw {
         /*
         MinidumpRawContext::ARM(ctx) => ctx.get_caller_frame(stack_memory),
@@ -27,12 +88,20 @@ fn get_caller_frame(
         MinidumpRawContext::SPARC(ctx) => ctx.get_caller_frame(stack_memory),
         MinidumpRawContext::MIPS(ctx) => ctx.get_caller_frame(stack_memory),
          */
-        MinidumpRawContext::Amd64(ref ctx) => {
-            ctx.get_caller_frame(&frame.context.valid, frame.trust, stack_memory, modules)
-        }
-        MinidumpRawContext::X86(ref ctx) => {
-            ctx.get_caller_frame(&frame.context.valid, frame.trust, stack_memory, modules)
-        }
+        MinidumpRawContext::Amd64(ref ctx) => ctx.get_caller_frame(
+            &frame.context.valid,
+            frame.trust,
+            stack_memory,
+            modules,
+            symbol_provider,
+        ),
+        MinidumpRawContext::X86(ref ctx) => ctx.get_caller_frame(
+            &frame.context.valid,
+            frame.trust,
+            stack_memory,
+            modules,
+            symbol_provider,
+        ),
         _ => None,
     }
 }
@@ -73,7 +142,7 @@ where
             fill_source_line_info(&mut frame, modules, symbol_provider);
             frames.push(frame);
             let last_frame = &frames.last().unwrap();
-            maybe_frame = get_caller_frame(last_frame, stack_memory, modules);
+            maybe_frame = get_caller_frame(last_frame, stack_memory, modules, symbol_provider);
         }
     } else {
         info = CallStackInfo::MissingContext;

--- a/minidump-processor/src/stackwalker/unwind.rs
+++ b/minidump-processor/src/stackwalker/unwind.rs
@@ -13,6 +13,7 @@ pub trait Unwind {
         valid: &MinidumpContextValidity,
         trust: FrameTrust,
         stack_memory: Option<&MinidumpMemory>,
+        grand_callee_frame: Option<&StackFrame>,
         modules: &MinidumpModuleList,
         symbol_provider: &P,
     ) -> Option<StackFrame>

--- a/minidump-processor/src/stackwalker/unwind.rs
+++ b/minidump-processor/src/stackwalker/unwind.rs
@@ -2,16 +2,20 @@
 // file at the top-level directory of this distribution.
 
 use crate::process_state::{FrameTrust, StackFrame};
+use crate::SymbolProvider;
 use minidump::{MinidumpContextValidity, MinidumpMemory, MinidumpModuleList};
 
 /// A trait for things that can unwind to a caller.
 pub trait Unwind {
     /// Get the caller frame of this frame.
-    fn get_caller_frame(
+    fn get_caller_frame<P>(
         &self,
         valid: &MinidumpContextValidity,
         trust: FrameTrust,
         stack_memory: Option<&MinidumpMemory>,
         modules: &MinidumpModuleList,
-    ) -> Option<StackFrame>;
+        symbol_provider: &P,
+    ) -> Option<StackFrame>
+    where
+        P: SymbolProvider;
 }

--- a/minidump-processor/src/stackwalker/x86.rs
+++ b/minidump-processor/src/stackwalker/x86.rs
@@ -24,13 +24,17 @@ const INSTRUCTION_REGISTER: &str = "eip";
 const STACK_POINTER_REGISTER: &str = "esp";
 const FRAME_POINTER_REGISTER: &str = "ebp";
 
-fn get_caller_by_frame_pointer(
+fn get_caller_by_frame_pointer<P>(
     ctx: &CONTEXT_X86,
     valid: &MinidumpContextValidity,
     _trust: FrameTrust,
     stack_memory: &MinidumpMemory,
     _modules: &MinidumpModuleList,
-) -> Option<StackFrame> {
+    _symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
     if let MinidumpContextValidity::Some(ref which) = valid {
         if !which.contains(FRAME_POINTER_REGISTER) {
             return None;
@@ -111,11 +115,11 @@ where
             return None;
         }
     }
-
     trace!("  ...context was good");
 
-    let instruction = ctx.eip;
-    let module = modules.module_at_address(instruction as u64)?;
+    let last_sp = ctx.esp;
+    let last_ip = ctx.eip;
+    let module = modules.module_at_address(last_ip as u64)?;
     trace!("  ...found module");
 
     let grand_callee_parameter_size = grand_callee_frame
@@ -123,7 +127,7 @@ where
         .unwrap_or(0);
 
     let mut stack_walker = CfiStackWalker {
-        instruction: instruction as u64,
+        instruction: last_ip as u64,
         grand_callee_parameter_size,
 
         callee_ctx: ctx,
@@ -138,13 +142,13 @@ where
     symbol_provider.walk_frame(module, &mut stack_walker)?;
     let caller_ip = stack_walker.caller_ctx.eip;
     let caller_sp = stack_walker.caller_ctx.esp;
-    let callee_sp = ctx.esp;
 
-    // Sanity-check the output
-    if !instruction_seems_valid(caller_ip, modules) {
+    // Don't accept obviously wrong instruction pointers.
+    if !instruction_seems_valid(caller_ip, modules, symbol_provider) {
         return None;
     }
-    if caller_sp <= callee_sp {
+    // Don't accept obviously wrong stack pointers.
+    if !stack_seems_valid(caller_sp, last_sp, stack_memory) {
         return None;
     }
 
@@ -156,17 +160,22 @@ where
     adjust_instruction(&mut frame, caller_ip);
     Some(frame)
 }
-fn get_caller_by_scan(
+
+fn get_caller_by_scan<P>(
     ctx: &CONTEXT_X86,
     valid: &MinidumpContextValidity,
     trust: FrameTrust,
     stack_memory: &MinidumpMemory,
     modules: &MinidumpModuleList,
-) -> Option<StackFrame> {
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
     // Stack scanning is just walking from the end of the frame until we encounter
     // a value on the stack that looks like a pointer into some code (it's an address
     // in a range covered by one of our modules). If we find such an instruction,
-    // we assume it's a ip value that was pushed by the CALL instruction that created
+    // we assume it's an ip value that was pushed by the CALL instruction that created
     // the current frame. The next frame is then assumed to end just before that
     // ip value.
     let last_bp = match valid {
@@ -200,7 +209,7 @@ fn get_caller_by_scan(
     for i in 0..scan_range {
         let address_of_ip = last_sp + i * POINTER_WIDTH;
         let caller_ip = stack_memory.get_memory_at_address(address_of_ip as u64)?;
-        if instruction_seems_valid(caller_ip, modules) {
+        if instruction_seems_valid(caller_ip, modules, symbol_provider) {
             // ip is pushed by CALL, so sp is just address_of_ip + ptr
             let caller_sp = address_of_ip + POINTER_WIDTH;
 
@@ -273,13 +282,37 @@ fn get_caller_by_scan(
 }
 
 #[allow(clippy::match_like_matches_macro)]
-fn instruction_seems_valid(instruction: Pointer, modules: &MinidumpModuleList) -> bool {
+fn instruction_seems_valid<P>(
+    instruction: Pointer,
+    modules: &MinidumpModuleList,
+    _symbol_provider: &P,
+) -> bool
+where
+    P: SymbolProvider,
+{
+    // NOTE: x86 has no notion of pointer canonicity (divergence from AMD64)
     if let Some(_module) = modules.module_at_address(instruction as u64) {
         // TODO: if mapped, check if this instruction actually maps to a function line
         true
     } else {
         false
     }
+}
+
+fn stack_seems_valid(
+    caller_sp: Pointer,
+    callee_sp: Pointer,
+    stack_memory: &MinidumpMemory,
+) -> bool {
+    // The stack shouldn't *grow* when we unwind
+    if caller_sp <= callee_sp {
+        return false;
+    }
+
+    // The stack pointer should be in the stack
+    stack_memory
+        .get_memory_at_address::<Pointer>(caller_sp as u64)
+        .is_some()
 }
 
 fn adjust_instruction(frame: &mut StackFrame, caller_ip: Pointer) {
@@ -300,7 +333,7 @@ impl Unwind for CONTEXT_X86 {
         stack_memory: Option<&MinidumpMemory>,
         grand_callee_frame: Option<&StackFrame>,
         modules: &MinidumpModuleList,
-        symbol_provider: &P,
+        syms: &P,
     ) -> Option<StackFrame>
     where
         P: SymbolProvider,
@@ -308,17 +341,11 @@ impl Unwind for CONTEXT_X86 {
         stack_memory
             .as_ref()
             .and_then(|stack| {
-                get_caller_by_cfi(
-                    self,
-                    valid,
-                    trust,
-                    stack,
-                    grand_callee_frame,
-                    modules,
-                    symbol_provider,
-                )
-                .or_else(|| get_caller_by_frame_pointer(self, valid, trust, stack, modules))
-                .or_else(|| get_caller_by_scan(self, valid, trust, stack, modules))
+                get_caller_by_cfi(self, valid, trust, stack, grand_callee_frame, modules, syms)
+                    .or_else(|| {
+                        get_caller_by_frame_pointer(self, valid, trust, stack, modules, syms)
+                    })
+                    .or_else(|| get_caller_by_scan(self, valid, trust, stack, modules, syms))
             })
             .and_then(|frame| {
                 // Treat an instruction address of 0 as end-of-stack.


### PR DESCRIPTION
This teaches breakpad-symbols to parse and evaluate STACK CFI exprs, and plumbs it through to the amd64/x86 stack walkers in minidump-processor. As a result, cfi-based unwinding now works on linux. [Example minidump-processor output on a firefox minidump](https://gist.github.com/Gankra/997852c049b197975045476e5d8ce099).

To do this, it introduces a FrameWalker trait in breakpad-symbols that abstracts away the details of mapping string register names to loads/stores from the context.

minidump-processor in turn introduces a CfiStackWalker that implements FrameWalker by generically wrapping up the callee's Context and a fresh caller Context. The Context trait is also beefed up to expose the necessary details.

Incidentally this also gives everything needed to implement cfi unwinding on ARM64, I would just need to copy-paste the setup code to wire it up (will do in a followup).

-----------

You may be wondering: why implement this logic in breakpad-symbols? 

Partially this is a matter of performance -- the RefCells in breakpad-symbols make it impossible to return the CfiRules by-reference for minidump-processor.

Partially this is a matter of design -- minidump-processor shouldn't concern itself with what CFI system is being used and how it's being loaded. In this way it should be plausible to swap out minidump-processor for symbolic, and to introduce native CFI handlers transparently (modulo changing some glue around).

The implementation of STACK CFI handling is separated out into its own module and could be transplanted into symbolic or where ever else without significant changes to the structure. It basically just takes in strings and a A Thing (FrameWalker) that abstracts away the details of the cpu context.


-----------

This is WIP because:

* [ ] I need to write tests (copy-paste them from breakpad).
* [x] I want to also knock out `WIN STACK` in this PR
* [x] Need to write detecting for bogus output (e.g. CFI giving us a nonsense $rip)

