### PR TITLE
support wasm and async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.72",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +156,7 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 name = "breakpad-symbols"
 version = "0.3.0"
 dependencies = [
+ "async-trait",
  "failure",
  "log",
  "minidump-common",
@@ -533,12 +545,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "futures"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -548,10 +576,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+dependencies = [
+ "autocfg",
+ "proc-macro-hack",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.72",
+]
 
 [[package]]
 name = "futures-sink"
@@ -572,12 +624,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
  "autocfg",
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite 0.2.6",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
  "slab",
 ]
 
@@ -1018,6 +1075,7 @@ name = "minidump-processor"
 version = "0.3.0"
 dependencies = [
  "addr2line 0.15.1",
+ "async-trait",
  "breakpad-symbols",
  "chrono",
  "clap",
@@ -1041,6 +1099,7 @@ dependencies = [
  "addr2line 0.15.1",
  "breakpad-symbols",
  "clap",
+ "futures",
  "log",
  "minidump",
  "minidump-processor",
@@ -1418,6 +1477,18 @@ dependencies = [
  "quote 1.0.9",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -20,6 +20,7 @@ nom = "~1.2.2"
 log = "0.4.1"
 reqwest = { version = "0.11.3", features = ["blocking", "gzip"] }
 failure = "0.1.1"
+async-trait = "0.1.50"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -21,13 +21,16 @@ clap = "2.33"
 failure = "0.1.1"
 gimli = "0.24"
 log = "0.4"
-memmap = "0.7.0"
 minidump = { version = "0.3.0", path = "../minidump" }
 object = "0.24"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.10.0"
 scroll = "0.10.2"
+async-trait = "0.1.50"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+memmap = "0.7.0"
 
 [dev-dependencies]
 test-assembler = "0.1.5"

--- a/minidump-processor/src/stackwalker/unwind.rs
+++ b/minidump-processor/src/stackwalker/unwind.rs
@@ -5,14 +5,17 @@ use crate::process_state::{FrameTrust, StackFrame};
 use crate::SymbolProvider;
 use minidump::{MinidumpContextValidity, MinidumpMemory, MinidumpModuleList};
 
+use async_trait::async_trait;
+
 /// A trait for things that can unwind to a caller.
+#[async_trait(?Send)]
 pub trait Unwind {
     /// Get the caller frame of this frame.
-    fn get_caller_frame<P>(
+    async fn get_caller_frame<P>(
         &self,
         valid: &MinidumpContextValidity,
         trust: FrameTrust,
-        stack_memory: Option<&MinidumpMemory>,
+        stack_memory: Option<&MinidumpMemory<'_>>,
         grand_callee_frame: Option<&StackFrame>,
         modules: &MinidumpModuleList,
         symbol_provider: &P,

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -23,4 +23,5 @@ log = "0.4"
 minidump = { version = "0.3.0", path = "../minidump" }
 minidump-processor = { version = "0.3.0", path = "../minidump-processor" }
 simplelog = "0.10.0"
+futures = "0.3"
 

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -16,7 +16,10 @@ use clap::{crate_authors, crate_version, App, Arg};
 use log::error;
 use simplelog::{ColorChoice, Config, LevelFilter, TermLogger, TerminalMode};
 
-fn print_minidump_process(
+use futures::executor::block_on;
+
+
+async fn print_minidump_process(
     path: &Path,
     symbol_paths: Vec<PathBuf>,
     symbol_urls: Vec<String>,
@@ -40,7 +43,7 @@ fn print_minidump_process(
         }
         provider.add(Box::new(DwarfSymbolizer::new()));
 
-        match minidump_processor::process_minidump(&dump, &provider) {
+        match minidump_processor::process_minidump(&dump, &provider).await {
             Ok(state) => {
                 let mut stdout = std::io::stdout();
                 if human {
@@ -192,12 +195,12 @@ fn main() {
         std::process::exit(1);
     }
 
-    print_minidump_process(
+    block_on(print_minidump_process(
         minidump_path,
         symbols_paths,
         symbols_urls,
         symbols_cache,
         human,
         pretty,
-    );
+    ));
 }

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -21,6 +21,8 @@ num-traits = "0.2"
 encoding = "0.2"
 chrono = "0.4.6"
 scroll = "0.10.2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memmap = "0.7.0"
 
 [dev-dependencies]

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -5,6 +5,7 @@ use chrono::prelude::*;
 use encoding::all::UTF_16LE;
 use encoding::{DecoderTrap, Encoding};
 use failure::Fail;
+#[cfg(not(target_arch = "wasm32"))]
 use memmap::Mmap;
 use num_traits::FromPrimitive;
 use scroll::ctx::{SizeWith, TryFromCtx};
@@ -2779,6 +2780,7 @@ impl MinidumpCrashpadInfo {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<'a> Minidump<'a, Mmap> {
     /// Read a `Minidump` from a `Path` to a file on disk.
     ///


### PR DESCRIPTION
This is a bit of a WIP PR, and I'm a Rust newbie so sorry for any obvious
mistakes. With these changes I was able to successfully symbolicate a crash in
the browser using a "FetchSymbolSupplier" to fetch symbols from a
CORS-supporting symbol server (see code below).

There are two main changes here:

1. Elide non-wasm-compatible code using `#[cfg(not(target_arch = "wasm32"))]`.
   The only place this is necessary is for usages of the `memmap` crate.
2. Make SymbolSupplier `async`, to support using `fetch()` in the browser.

Of these, the second change is far more invasive. I'd happily change the
approach if there were a less invasive way to allow fetching symbols in the
browser--for example, there might be a way to have a "cooperative" scheduler
for fetching symbols that allowed all the rust code to be synchronous, e.g. by
returning something like `Err(MissingSymbolFile(debug_id = ..., name = ...))`
when a symbol file is missing, so that then the "driver" can go fetch that
symbol asynchronously, and once that's done, retry processing with that symbol
file being synchronously available, and possibly receiving another "symbol file
missing" error & repeating the process.

Is this a change that would potentially be considered mergeable? Either in part
or in whole?

```rust
/// An implementation of `SymbolSupplier` that loads Breakpad text-format symbols from HTTP
/// URLs over fetch().
pub struct FetchSymbolSupplier {
    /// URLs to search for symbols.
    urls: Vec<String>,
}

impl FetchSymbolSupplier {
    pub fn new(
        urls: Vec<String>,
    ) -> FetchSymbolSupplier {
        let urls = urls
            .into_iter()
            .map(|mut u| {
                if !u.ends_with('/') {
                    u.push('/');
                }
                u
            })
            .collect();
        FetchSymbolSupplier {
            urls,
        }
    }
}

async fn fetch_symbol_file(
    base_url: &str,
    rel_path: &str,
) -> Result<Vec<u8>, Error> {
    let url = base_url.to_owned() + rel_path;
    let mut opts = RequestInit::new();
    opts.method("GET");
    opts.mode(RequestMode::Cors);
    opts.cache(RequestCache::ForceCache);

    let request = Request::new_with_str_and_init(&url, &opts).unwrap();

    let window = web_sys::window().unwrap();
    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await.map_err(|_| Error::IoError)?;

    assert!(resp_value.is_instance_of::<Response>());
    let resp: Response = resp_value.dyn_into().unwrap();

    let buf = JsFuture::from(resp.array_buffer().unwrap()).await.unwrap();

    let typebuf = js_sys::Uint8Array::new(&buf);
    let mut body = vec![0; typebuf.length() as usize];
    typebuf.copy_to(&mut body[..]);
    Ok(body.to_vec())
}

#[async_trait(?Send)]
impl SymbolSupplier for FetchSymbolSupplier {
    async fn locate_symbols(&self, module: &dyn Module) -> SymbolResult {
        log("here");
        // Check local paths first.
        if let Some(rel_path) = relative_symbol_path(module, "sym") {
            for ref url in self.urls.iter() {
                if let Ok(buf) =
                    fetch_symbol_file(url, &rel_path).await
                {
                    return SymbolFile::from_bytes(&buf)
                        .map(SymbolResult::Ok)
                        .unwrap_or_else(SymbolResult::LoadError);
                }
            }
        }
        SymbolResult::NotFound
    }
}
```

