### PR TITLE
Add unwinders for ARM, ARM64, and ARM64_OLD 

### DIFF
--- a/breakpad-symbols/src/sym_file/types.rs
+++ b/breakpad-symbols/src/sym_file/types.rs
@@ -71,8 +71,14 @@ pub struct Function {
 }
 
 impl Function {
-    pub fn memory_range(&self) -> Range<u64> {
-        Range::new(self.address, self.address + self.size as u64 - 1)
+    pub fn memory_range(&self) -> Option<Range<u64>> {
+        if self.size == 0 {
+            return None;
+        }
+        Some(Range::new(
+            self.address,
+            self.address.checked_add(self.size as u64)? - 1,
+        ))
     }
 }
 
@@ -97,8 +103,14 @@ pub struct StackInfoCfi {
 }
 
 impl StackInfoCfi {
-    pub fn memory_range(&self) -> Range<u64> {
-        Range::new(self.init.address, self.init.address + self.size as u64 - 1)
+    pub fn memory_range(&self) -> Option<Range<u64>> {
+        if self.size == 0 {
+            return None;
+        }
+        Some(Range::new(
+            self.init.address,
+            self.init.address.checked_add(self.size as u64)? - 1,
+        ))
     }
 }
 
@@ -144,8 +156,14 @@ pub struct StackInfoWin {
 }
 
 impl StackInfoWin {
-    pub fn memory_range(&self) -> Range<u64> {
-        Range::new(self.address, self.address + self.size as u64 - 1)
+    pub fn memory_range(&self) -> Option<Range<u64>> {
+        if self.size == 0 {
+            return None;
+        }
+        Some(Range::new(
+            self.address,
+            self.address.checked_add(self.size as u64)? - 1,
+        ))
     }
 }
 

--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -1164,7 +1164,7 @@ pub struct CONTEXT_AMD64 {
 }
 
 /// ARM floating point state
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Default, Pread, SizeWith)]
 pub struct FLOATING_SAVE_AREA_ARM {
     pub fpscr: u64,
     pub regs: [u64; 32],
@@ -1175,7 +1175,7 @@ pub struct FLOATING_SAVE_AREA_ARM {
 ///
 /// This is a Breakpad extension, and does not match the definition of `CONTEXT` for ARM
 /// in WinNT.h.
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Default, Pread, SizeWith)]
 pub struct CONTEXT_ARM {
     pub context_flags: u32,
     pub iregs: [u32; 16],
@@ -1194,8 +1194,20 @@ pub enum ArmRegisterNumbers {
     ProgramCounter = 15,
 }
 
+impl ArmRegisterNumbers {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::IosFramePointer => "r7",
+            Self::FramePointer => "r11",
+            Self::StackPointer => "r13",
+            Self::LinkRegister => "r14",
+            Self::ProgramCounter => "r15",
+        }
+    }
+}
+
 /// aarch64 floating point state (old)
-#[derive(Debug, Clone, Copy, Pread, SizeWith)]
+#[derive(Debug, Clone, Copy, Default, Pread, SizeWith)]
 pub struct FLOATING_SAVE_AREA_ARM64_OLD {
     pub fpsr: u32,
     pub fpcr: u32,
@@ -1205,7 +1217,7 @@ pub struct FLOATING_SAVE_AREA_ARM64_OLD {
 /// An old aarch64 (arm64) CPU context
 ///
 /// This is a Breakpad extension.
-#[derive(Debug, Clone, Copy, Pread, SizeWith)]
+#[derive(Debug, Clone, Copy, Default, Pread, SizeWith)]
 #[repr(packed)]
 pub struct CONTEXT_ARM64_OLD {
     pub context_flags: u64,
@@ -1216,7 +1228,7 @@ pub struct CONTEXT_ARM64_OLD {
 }
 
 /// aarch64 floating point state
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Default, Pread, SizeWith)]
 pub struct FLOATING_SAVE_AREA_ARM64 {
     pub regs: [u128; 32usize],
     pub fpsr: u32,
@@ -1227,7 +1239,7 @@ pub struct FLOATING_SAVE_AREA_ARM64 {
 ///
 /// This is a Breakpad extension, and does not match the definition of `CONTEXT` for aarch64
 /// in WinNT.h.
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Default, Clone, Pread, SizeWith)]
 pub struct CONTEXT_ARM64 {
     pub context_flags: u32,
     pub cpsr: u32,
@@ -1248,6 +1260,17 @@ pub enum Arm64RegisterNumbers {
     LinkRegister = 30,
     StackPointer = 31,
     ProgramCounter = 32,
+}
+
+impl Arm64RegisterNumbers {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::FramePointer => "x29",
+            Self::LinkRegister => "x30",
+            Self::StackPointer => "sp",
+            Self::ProgramCounter => "pc",
+        }
+    }
 }
 
 /// MIPS floating point state

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -187,7 +187,6 @@ where
         // Just give an empty list, simplifies things.
         Err(_) => MinidumpUnloadedModuleList::new(),
     };
-
     let memory_list = dump.get_stream::<MinidumpMemoryList>().ok();
 
     // Get memory list

--- a/minidump-processor/src/stackwalker/arm.rs
+++ b/minidump-processor/src/stackwalker/arm.rs
@@ -1,0 +1,310 @@
+// Copyright 2015 Ted Mielczarek. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+
+// NOTE: arm64_old.rs and arm64.rs should be identical except for the names of
+// their context types.
+
+use crate::process_state::{FrameTrust, StackFrame};
+use crate::stackwalker::unwind::Unwind;
+use crate::stackwalker::CfiStackWalker;
+use crate::SymbolProvider;
+use log::trace;
+use minidump::{
+    CpuContext, MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
+    MinidumpRawContext,
+};
+use std::collections::HashSet;
+
+type ArmContext = minidump::format::CONTEXT_ARM;
+type Pointer = <ArmContext as CpuContext>::Register;
+type Registers = minidump::format::ArmRegisterNumbers;
+
+const POINTER_WIDTH: Pointer = std::mem::size_of::<Pointer>() as Pointer;
+const FRAME_POINTER: &str = Registers::FramePointer.name();
+const STACK_POINTER: &str = Registers::StackPointer.name();
+const PROGRAM_COUNTER: &str = Registers::ProgramCounter.name();
+const LINK_REGISTER: &str = Registers::LinkRegister.name();
+
+fn get_caller_by_frame_pointer<P>(
+    ctx: &ArmContext,
+    valid: &MinidumpContextValidity,
+    _trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    modules: &MinidumpModuleList,
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
+    // Assume that the standard %fp-using ARM calling convention is in use.
+    // The main quirk of this ABI is that the return address doesn't need to
+    // be restored from the stack -- it's already in the link register (lr).
+    // But that means we need to save/restore lr itself so that the *caller's*
+    // return address can be recovered.
+    //
+    // In the standard calling convention, the following happens:
+    //
+    // PUSH fp, lr    (save fp and lr to the stack -- ARM pushes in pairs)
+    // fp := sp       (update the frame pointer to the current stack pointer)
+    // lr := pc       (save the return address in the link register)
+    //
+    // So to restore the caller's registers, we have:
+    //
+    // pc := lr
+    // sp := fp + ptr*2
+    // lr := *(fp + ptr)
+    // fp := *fp
+    let last_fp = ctx.get_register(FRAME_POINTER, valid)?;
+    let last_sp = ctx.get_register(STACK_POINTER, valid)?;
+    // Unlike ARM64, we don't bother trying really hard to restore lr
+    let last_lr = ctx.get_register(LINK_REGISTER, valid)?;
+
+    let caller_fp = stack_memory.get_memory_at_address(last_fp as u64)?;
+    let caller_lr = stack_memory.get_memory_at_address(last_fp as u64 + POINTER_WIDTH as u64)?;
+    let caller_pc = last_lr;
+
+    // TODO: why does breakpad do this? how can fp be null by here?
+    let caller_sp = if last_fp == 0 {
+        last_sp
+    } else {
+        last_fp + POINTER_WIDTH * 2
+    };
+
+    // If the recovered pc is not a canonical address it can't be
+    // the return address, so fp must not have been a frame pointer.
+
+    // Breakpad doesn't validate that the fp seems reasonable
+
+    // Don't accept obviously wrong instruction pointers.
+    if !instruction_seems_valid(caller_pc, modules, symbol_provider) {
+        return None;
+    }
+    // Don't accept obviously wrong stack pointers.
+    if !stack_seems_valid(caller_sp, last_sp, stack_memory) {
+        return None;
+    }
+
+    let mut caller_ctx = ArmContext::default();
+    caller_ctx.set_register(PROGRAM_COUNTER, caller_pc);
+    caller_ctx.set_register(LINK_REGISTER, caller_lr);
+    caller_ctx.set_register(FRAME_POINTER, caller_fp);
+    caller_ctx.set_register(STACK_POINTER, caller_sp);
+
+    let mut valid = HashSet::new();
+    valid.insert(PROGRAM_COUNTER);
+    valid.insert(LINK_REGISTER);
+    valid.insert(FRAME_POINTER);
+    valid.insert(STACK_POINTER);
+
+    let context = MinidumpContext {
+        raw: MinidumpRawContext::Arm(caller_ctx),
+        valid: MinidumpContextValidity::Some(valid),
+    };
+    let mut frame = StackFrame::from_context(context, FrameTrust::FramePointer);
+    adjust_instruction(&mut frame, caller_pc);
+    Some(frame)
+}
+
+fn get_caller_by_cfi<P>(
+    ctx: &ArmContext,
+    valid: &MinidumpContextValidity,
+    _trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    grand_callee_frame: Option<&StackFrame>,
+    modules: &MinidumpModuleList,
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
+    trace!("trying to get frame by cfi");
+
+    let last_sp = ctx.get_register(STACK_POINTER, valid)?;
+    let last_pc = ctx.get_register(PROGRAM_COUNTER, valid)?;
+
+    trace!("  ...context was good");
+
+    let module = modules.module_at_address(last_pc as u64)?;
+    trace!("  ...found module");
+
+    let grand_callee_parameter_size = grand_callee_frame
+        .and_then(|f| f.parameter_size)
+        .unwrap_or(0);
+
+    let mut stack_walker = CfiStackWalker {
+        instruction: last_pc as u64,
+        grand_callee_parameter_size,
+
+        callee_ctx: ctx,
+        callee_validity: valid,
+
+        caller_ctx: ArmContext::default(),
+        caller_validity: HashSet::new(),
+
+        stack_memory,
+    };
+
+    symbol_provider.walk_frame(module, &mut stack_walker)?;
+    let caller_pc = stack_walker.caller_ctx.get_register_always(PROGRAM_COUNTER);
+    let caller_sp = stack_walker.caller_ctx.get_register_always(STACK_POINTER);
+
+    // Don't accept obviously wrong instruction pointers.
+    if !instruction_seems_valid(caller_pc, modules, symbol_provider) {
+        return None;
+    }
+    // Don't accept obviously wrong stack pointers.
+    if !stack_seems_valid(caller_sp, last_sp, stack_memory) {
+        return None;
+    }
+
+    let context = MinidumpContext {
+        raw: MinidumpRawContext::Arm(stack_walker.caller_ctx),
+        valid: MinidumpContextValidity::Some(stack_walker.caller_validity),
+    };
+    let mut frame = StackFrame::from_context(context, FrameTrust::CallFrameInfo);
+    adjust_instruction(&mut frame, caller_pc);
+    Some(frame)
+}
+
+fn get_caller_by_scan<P>(
+    ctx: &ArmContext,
+    valid: &MinidumpContextValidity,
+    trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    modules: &MinidumpModuleList,
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
+    // Stack scanning is just walking from the end of the frame until we encounter
+    // a value on the stack that looks like a pointer into some code (it's an address
+    // in a range covered by one of our modules). If we find such an instruction,
+    // we assume it's an pc value that was pushed by the CALL instruction that created
+    // the current frame. The next frame is then assumed to end just before that
+    // pc value.
+    let last_sp = ctx.get_register(STACK_POINTER, valid)?;
+
+    // Number of pointer-sized values to scan through in our search.
+    let default_scan_range = 40;
+    let extended_scan_range = default_scan_range * 4;
+
+    // Breakpad devs found that the first frame of an unwind can be really messed up,
+    // and therefore benefits from a longer scan. Let's do it too.
+    let scan_range = if let FrameTrust::Context = trust {
+        extended_scan_range
+    } else {
+        default_scan_range
+    };
+
+    for i in 0..scan_range {
+        let address_of_pc = last_sp + i * POINTER_WIDTH;
+        let caller_pc = stack_memory.get_memory_at_address(address_of_pc as u64)?;
+        if instruction_seems_valid(caller_pc, modules, symbol_provider) {
+            // pc is pushed by CALL, so sp is just address_of_pc + ptr
+            let caller_sp = address_of_pc + POINTER_WIDTH;
+
+            // Don't do any more validation, and don't try to restore fp
+            // (that's what breakpad does!)
+
+            let mut caller_ctx = ArmContext::default();
+            caller_ctx.set_register(PROGRAM_COUNTER, caller_pc);
+            caller_ctx.set_register(STACK_POINTER, caller_sp);
+
+            let mut valid = HashSet::new();
+            valid.insert(PROGRAM_COUNTER);
+            valid.insert(STACK_POINTER);
+
+            let context = MinidumpContext {
+                raw: MinidumpRawContext::Arm(caller_ctx),
+                valid: MinidumpContextValidity::Some(valid),
+            };
+            let mut frame = StackFrame::from_context(context, FrameTrust::Scan);
+            adjust_instruction(&mut frame, caller_pc);
+            return Some(frame);
+        }
+    }
+
+    None
+}
+
+#[allow(clippy::match_like_matches_macro)]
+fn instruction_seems_valid<P>(
+    instruction: Pointer,
+    modules: &MinidumpModuleList,
+    _symbol_provider: &P,
+) -> bool
+where
+    P: SymbolProvider,
+{
+    if let Some(_module) = modules.module_at_address(instruction as u64) {
+        // TODO: if mapped, check if this instruction actually maps to a function line
+        true
+    } else {
+        false
+    }
+}
+
+fn stack_seems_valid(
+    caller_sp: Pointer,
+    callee_sp: Pointer,
+    stack_memory: &MinidumpMemory,
+) -> bool {
+    // The stack shouldn't *grow* when we unwind
+    if caller_sp <= callee_sp {
+        return false;
+    }
+
+    // The stack pointer should be in the stack
+    stack_memory
+        .get_memory_at_address::<Pointer>(caller_sp as u64)
+        .is_some()
+}
+
+fn adjust_instruction(frame: &mut StackFrame, caller_pc: Pointer) {
+    // A caller's pc is the return address, which is the instruction
+    // after the CALL that caused us to arrive at the callee. Set
+    // the value to one less than that, so it points within the
+    // CALL instruction.
+    if caller_pc > 0 {
+        frame.instruction = caller_pc as u64 - 1;
+    }
+}
+
+impl Unwind for ArmContext {
+    fn get_caller_frame<P>(
+        &self,
+        valid: &MinidumpContextValidity,
+        trust: FrameTrust,
+        stack_memory: Option<&MinidumpMemory>,
+        grand_callee_frame: Option<&StackFrame>,
+        modules: &MinidumpModuleList,
+        syms: &P,
+    ) -> Option<StackFrame>
+    where
+        P: SymbolProvider,
+    {
+        stack_memory
+            .as_ref()
+            .and_then(|stack| {
+                get_caller_by_cfi(self, valid, trust, stack, grand_callee_frame, modules, syms)
+                    .or_else(|| {
+                        get_caller_by_frame_pointer(self, valid, trust, stack, modules, syms)
+                    })
+                    .or_else(|| get_caller_by_scan(self, valid, trust, stack, modules, syms))
+            })
+            .and_then(|frame| {
+                // Treat an instruction address of 0 as end-of-stack.
+                if frame.context.get_instruction_pointer() == 0 {
+                    return None;
+                }
+                // If the new stack pointer is at a lower address than the old,
+                // then that's clearly incorrect. Treat this as end-of-stack to
+                // enforce progress and avoid infinite loops.
+                if frame.context.get_stack_pointer() <= self.get_register_always("sp") as u64 {
+                    return None;
+                }
+                Some(frame)
+            })
+    }
+}

--- a/minidump-processor/src/stackwalker/arm64.rs
+++ b/minidump-processor/src/stackwalker/arm64.rs
@@ -78,6 +78,9 @@ where
         last_fp + POINTER_WIDTH * 2
     };
 
+    // TODO: restore all the other callee-save registers that weren't touched.
+    // unclear: does this mean we need to be aware of ".undef" entries at this point?
+
     // Breakpad's tests don't like it we validate the frame pointer's value,
     // so we don't check that.
 
@@ -200,6 +203,7 @@ where
     };
 
     symbol_provider.walk_frame(module, &mut stack_walker)?;
+
     let caller_pc = stack_walker.caller_ctx.get_register_always(PROGRAM_COUNTER);
     let caller_sp = stack_walker.caller_ctx.get_register_always(STACK_POINTER);
 
@@ -311,7 +315,7 @@ fn stack_seems_valid(
     stack_memory: &MinidumpMemory,
 ) -> bool {
     // The stack shouldn't *grow* when we unwind
-    if caller_sp <= callee_sp {
+    if caller_sp < callee_sp {
         return false;
     }
 
@@ -369,7 +373,7 @@ impl Unwind for ArmContext {
                 // If the new stack pointer is at a lower address than the old,
                 // then that's clearly incorrect. Treat this as end-of-stack to
                 // enforce progress and avoid infinite loops.
-                if frame.context.get_stack_pointer() <= self.get_register_always("sp") {
+                if frame.context.get_stack_pointer() < self.get_register_always("sp") {
                     return None;
                 }
                 Some(frame)

--- a/minidump-processor/src/stackwalker/arm64.rs
+++ b/minidump-processor/src/stackwalker/arm64.rs
@@ -1,0 +1,378 @@
+// Copyright 2015 Ted Mielczarek. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+
+// NOTE: arm64_old.rs and arm64.rs should be identical except for the names of
+// their context types.
+
+use crate::process_state::{FrameTrust, StackFrame};
+use crate::stackwalker::unwind::Unwind;
+use crate::stackwalker::CfiStackWalker;
+use crate::SymbolProvider;
+use log::trace;
+use minidump::{
+    CpuContext, MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
+    MinidumpRawContext,
+};
+use std::collections::HashSet;
+
+type ArmContext = minidump::format::CONTEXT_ARM64;
+type Pointer = <ArmContext as CpuContext>::Register;
+type Registers = minidump::format::Arm64RegisterNumbers;
+
+const POINTER_WIDTH: Pointer = std::mem::size_of::<Pointer>() as Pointer;
+const FRAME_POINTER: &str = Registers::FramePointer.name();
+const STACK_POINTER: &str = Registers::StackPointer.name();
+const LINK_REGISTER: &str = Registers::LinkRegister.name();
+const PROGRAM_COUNTER: &str = Registers::ProgramCounter.name();
+
+fn get_caller_by_frame_pointer<P>(
+    ctx: &ArmContext,
+    valid: &MinidumpContextValidity,
+    _trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    grand_callee_frame: Option<&StackFrame>,
+    modules: &MinidumpModuleList,
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
+    // Assume that the standard %fp-using ARM64 calling convention is in use.
+    // The main quirk of this ABI is that the return address doesn't need to
+    // be restored from the stack -- it's already in the link register (lr).
+    // But that means we need to save/restore lr itself so that the *caller's*
+    // return address can be recovered.
+    //
+    // In the standard calling convention, the following happens:
+    //
+    // PUSH fp, lr    (save fp and lr to the stack -- ARM64 pushes in pairs)
+    // fp := sp       (update the frame pointer to the current stack pointer)
+    // lr := pc       (save the return address in the link register)
+    //
+    // So to restore the caller's registers, we have:
+    //
+    // pc := lr
+    // sp := fp + ptr*2
+    // lr := *(fp + ptr)
+    // fp := *fp
+
+    let last_fp = ctx.get_register(FRAME_POINTER, valid)?;
+    let last_sp = ctx.get_register(STACK_POINTER, valid)?;
+    let last_lr = match ctx.get_register(LINK_REGISTER, valid) {
+        Some(lr) => lr,
+        None => {
+            // TODO: it would be good to write this back to the callee's ctx/validity
+            get_link_register_by_frame_pointer(ctx, valid, stack_memory, grand_callee_frame)?
+        }
+    };
+
+    let caller_fp = stack_memory.get_memory_at_address(last_fp as u64)?;
+    let caller_lr = stack_memory.get_memory_at_address(last_fp + POINTER_WIDTH as u64)?;
+    let caller_lr = ptr_auth_strip(caller_lr);
+    let caller_pc = last_lr;
+
+    // TODO: why does breakpad do this? How could we get this far with a null fp?
+    let caller_sp = if last_fp == 0 {
+        last_sp
+    } else {
+        last_fp + POINTER_WIDTH * 2
+    };
+
+    // Breakpad's tests don't like it we validate the frame pointer's value,
+    // so we don't check that.
+
+    // Don't accept obviously wrong instruction pointers.
+    if !instruction_seems_valid(caller_pc, modules, symbol_provider) {
+        return None;
+    }
+
+    // Don't accept obviously wrong stack pointers.
+    if !stack_seems_valid(caller_sp, last_sp, stack_memory) {
+        return None;
+    }
+
+    let mut caller_ctx = ArmContext::default();
+    caller_ctx.set_register(PROGRAM_COUNTER, caller_pc);
+    caller_ctx.set_register(LINK_REGISTER, caller_lr);
+    caller_ctx.set_register(FRAME_POINTER, caller_fp);
+    caller_ctx.set_register(STACK_POINTER, caller_sp);
+
+    let mut valid = HashSet::new();
+    valid.insert(PROGRAM_COUNTER);
+    valid.insert(LINK_REGISTER);
+    valid.insert(FRAME_POINTER);
+    valid.insert(STACK_POINTER);
+
+    let context = MinidumpContext {
+        raw: MinidumpRawContext::Arm64(caller_ctx),
+        valid: MinidumpContextValidity::Some(valid),
+    };
+    let mut frame = StackFrame::from_context(context, FrameTrust::FramePointer);
+    adjust_instruction(&mut frame, caller_pc);
+    Some(frame)
+}
+
+/// Restores the callee's link register from the stack.
+fn get_link_register_by_frame_pointer(
+    ctx: &ArmContext,
+    valid: &MinidumpContextValidity,
+    stack_memory: &MinidumpMemory,
+    grand_callee_frame: Option<&StackFrame>,
+) -> Option<Pointer> {
+    // It may happen that whatever unwinding strategy we're using managed to
+    // restore %fp but didn't restore %lr. Frame-pointer-based unwinding requires
+    // %lr because it contains the return address (the caller's %pc).
+    //
+    // In the standard ARM64 calling convention %fp and %lr are pushed together,
+    // so if the grand-callee appears to have been called with that convention
+    // then we can recover %lr using its %fp.
+
+    // We need the grand_callee_frame's frame pointer
+    let grand_callee_frame = grand_callee_frame?;
+    let last_last_fp = if let MinidumpRawContext::Arm64(ref ctx) = grand_callee_frame.context.raw {
+        ctx.get_register(FRAME_POINTER, &grand_callee_frame.context.valid)?
+    } else {
+        return None;
+    };
+    let presumed_last_fp: Pointer = stack_memory.get_memory_at_address(last_last_fp as u64)?;
+
+    // Make sure fp and sp aren't obviously garbage (are well-ordered)
+    let last_fp = ctx.get_register(FRAME_POINTER, valid)?;
+    let last_sp = ctx.get_register(STACK_POINTER, valid)?;
+    if last_fp <= last_sp {
+        return None;
+    }
+
+    // Make sure the grand-callee and callee agree on the value of fp
+    if presumed_last_fp != last_fp {
+        return None;
+    }
+
+    // Now that we're pretty confident that frame pointers are valid, restore
+    // the callee's %lr, which should be right next to where its %fp is saved.
+    let last_lr = stack_memory.get_memory_at_address(last_last_fp + POINTER_WIDTH)?;
+
+    Some(ptr_auth_strip(last_lr))
+}
+
+fn ptr_auth_strip(ptr: Pointer) -> Pointer {
+    // TODO: attempt to remove ARM pointer authentication obfuscation
+    ptr
+}
+
+fn get_caller_by_cfi<P>(
+    ctx: &ArmContext,
+    valid: &MinidumpContextValidity,
+    _trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    grand_callee_frame: Option<&StackFrame>,
+    modules: &MinidumpModuleList,
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
+    trace!("trying to get frame by cfi");
+
+    let last_sp = ctx.get_register(STACK_POINTER, valid)?;
+    let last_pc = ctx.get_register(PROGRAM_COUNTER, valid)?;
+
+    trace!("  ...context was good");
+
+    let module = modules.module_at_address(last_pc as u64)?;
+    trace!("  ...found module");
+
+    let grand_callee_parameter_size = grand_callee_frame
+        .and_then(|f| f.parameter_size)
+        .unwrap_or(0);
+
+    let mut stack_walker = CfiStackWalker {
+        instruction: last_pc as u64,
+        grand_callee_parameter_size,
+
+        callee_ctx: ctx,
+        callee_validity: valid,
+
+        caller_ctx: ArmContext::default(),
+        caller_validity: HashSet::new(),
+
+        stack_memory,
+    };
+
+    symbol_provider.walk_frame(module, &mut stack_walker)?;
+    let caller_pc = stack_walker.caller_ctx.get_register_always(PROGRAM_COUNTER);
+    let caller_sp = stack_walker.caller_ctx.get_register_always(STACK_POINTER);
+
+    // Don't accept obviously wrong instruction pointers.
+    if !instruction_seems_valid(caller_pc, modules, symbol_provider) {
+        return None;
+    }
+    // Don't accept obviously wrong stack pointers.
+    if !stack_seems_valid(caller_sp, last_sp, stack_memory) {
+        return None;
+    }
+
+    let context = MinidumpContext {
+        raw: MinidumpRawContext::Arm64(stack_walker.caller_ctx),
+        valid: MinidumpContextValidity::Some(stack_walker.caller_validity),
+    };
+    let mut frame = StackFrame::from_context(context, FrameTrust::CallFrameInfo);
+    adjust_instruction(&mut frame, caller_pc);
+    Some(frame)
+}
+
+fn get_caller_by_scan<P>(
+    ctx: &ArmContext,
+    valid: &MinidumpContextValidity,
+    trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    modules: &MinidumpModuleList,
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
+    // Stack scanning is just walking from the end of the frame until we encounter
+    // a value on the stack that looks like a pointer into some code (it's an address
+    // in a range covered by one of our modules). If we find such an instruction,
+    // we assume it's an pc value that was pushed by the CALL instruction that created
+    // the current frame. The next frame is then assumed to end just before that
+    // pc value.
+    let last_sp = ctx.get_register(STACK_POINTER, valid)?;
+
+    // Number of pointer-sized values to scan through in our search.
+    let default_scan_range = 40;
+    let extended_scan_range = default_scan_range * 4;
+
+    // Breakpad devs found that the first frame of an unwind can be really messed up,
+    // and therefore benefits from a longer scan. Let's do it too.
+    let scan_range = if let FrameTrust::Context = trust {
+        extended_scan_range
+    } else {
+        default_scan_range
+    };
+
+    for i in 0..scan_range {
+        let address_of_pc = last_sp + i * POINTER_WIDTH;
+        let caller_pc = stack_memory.get_memory_at_address(address_of_pc as u64)?;
+        if instruction_seems_valid(caller_pc, modules, symbol_provider) {
+            // pc is pushed by CALL, so sp is just address_of_pc + ptr
+            let caller_sp = address_of_pc + POINTER_WIDTH;
+
+            // Don't do any more validation, and don't try to restore fp
+            // (that's what breakpad does!)
+
+            let mut caller_ctx = ArmContext::default();
+            caller_ctx.set_register(PROGRAM_COUNTER, caller_pc);
+            caller_ctx.set_register(STACK_POINTER, caller_sp);
+
+            let mut valid = HashSet::new();
+            valid.insert(PROGRAM_COUNTER);
+            valid.insert(STACK_POINTER);
+
+            let context = MinidumpContext {
+                raw: MinidumpRawContext::Arm64(caller_ctx),
+                valid: MinidumpContextValidity::Some(valid),
+            };
+            let mut frame = StackFrame::from_context(context, FrameTrust::Scan);
+            adjust_instruction(&mut frame, caller_pc);
+            return Some(frame);
+        }
+    }
+
+    None
+}
+
+#[allow(clippy::match_like_matches_macro)]
+fn instruction_seems_valid<P>(
+    instruction: Pointer,
+    modules: &MinidumpModuleList,
+    _symbol_provider: &P,
+) -> bool
+where
+    P: SymbolProvider,
+{
+    // Reject instructions in the first page or above the user-space threshold.
+    if !(0x1000..=0x000fffffffffffff).contains(&instruction) {
+        return false;
+    }
+
+    if let Some(_module) = modules.module_at_address(instruction as u64) {
+        // TODO: if mapped, check if this instruction actually maps to a function line
+        true
+    } else {
+        false
+    }
+}
+
+fn stack_seems_valid(
+    caller_sp: Pointer,
+    callee_sp: Pointer,
+    stack_memory: &MinidumpMemory,
+) -> bool {
+    // The stack shouldn't *grow* when we unwind
+    if caller_sp <= callee_sp {
+        return false;
+    }
+
+    // The stack pointer should be in the stack
+    stack_memory
+        .get_memory_at_address::<Pointer>(caller_sp as u64)
+        .is_some()
+}
+
+fn adjust_instruction(frame: &mut StackFrame, caller_pc: Pointer) {
+    // A caller's pc is the return address, which is the instruction
+    // after the CALL that caused us to arrive at the callee. Set
+    // the value to one less than that, so it points within the
+    // CALL instruction.
+    if caller_pc > 0 {
+        frame.instruction = caller_pc as u64 - 1;
+    }
+}
+
+impl Unwind for ArmContext {
+    fn get_caller_frame<P>(
+        &self,
+        valid: &MinidumpContextValidity,
+        trust: FrameTrust,
+        stack_memory: Option<&MinidumpMemory>,
+        grand_callee_frame: Option<&StackFrame>,
+        modules: &MinidumpModuleList,
+        syms: &P,
+    ) -> Option<StackFrame>
+    where
+        P: SymbolProvider,
+    {
+        stack_memory
+            .as_ref()
+            .and_then(|stack| {
+                get_caller_by_cfi(self, valid, trust, stack, grand_callee_frame, modules, syms)
+                    .or_else(|| {
+                        get_caller_by_frame_pointer(
+                            self,
+                            valid,
+                            trust,
+                            stack,
+                            grand_callee_frame,
+                            modules,
+                            syms,
+                        )
+                    })
+                    .or_else(|| get_caller_by_scan(self, valid, trust, stack, modules, syms))
+            })
+            .and_then(|frame| {
+                // Treat an instruction address of 0 as end-of-stack.
+                if frame.context.get_instruction_pointer() == 0 {
+                    return None;
+                }
+                // If the new stack pointer is at a lower address than the old,
+                // then that's clearly incorrect. Treat this as end-of-stack to
+                // enforce progress and avoid infinite loops.
+                if frame.context.get_stack_pointer() <= self.get_register_always("sp") {
+                    return None;
+                }
+                Some(frame)
+            })
+    }
+}

--- a/minidump-processor/src/stackwalker/arm64_old.rs
+++ b/minidump-processor/src/stackwalker/arm64_old.rs
@@ -1,0 +1,379 @@
+// Copyright 2015 Ted Mielczarek. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+
+// NOTE: arm64_old.rs and arm64.rs should be identical except for the names of
+// their context types.
+
+use crate::process_state::{FrameTrust, StackFrame};
+use crate::stackwalker::unwind::Unwind;
+use crate::stackwalker::CfiStackWalker;
+use crate::SymbolProvider;
+use log::trace;
+use minidump::{
+    CpuContext, MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
+    MinidumpRawContext,
+};
+use std::collections::HashSet;
+
+type ArmContext = minidump::format::CONTEXT_ARM64_OLD;
+type Pointer = <ArmContext as CpuContext>::Register;
+type Registers = minidump::format::Arm64RegisterNumbers;
+
+const POINTER_WIDTH: Pointer = std::mem::size_of::<Pointer>() as Pointer;
+const FRAME_POINTER: &str = Registers::FramePointer.name();
+const STACK_POINTER: &str = Registers::StackPointer.name();
+const LINK_REGISTER: &str = Registers::LinkRegister.name();
+const PROGRAM_COUNTER: &str = Registers::ProgramCounter.name();
+
+fn get_caller_by_frame_pointer<P>(
+    ctx: &ArmContext,
+    valid: &MinidumpContextValidity,
+    _trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    grand_callee_frame: Option<&StackFrame>,
+    modules: &MinidumpModuleList,
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
+    // Assume that the standard %fp-using ARM64 calling convention is in use.
+    // The main quirk of this ABI is that the return address doesn't need to
+    // be restored from the stack -- it's already in the link register (lr).
+    // But that means we need to save/restore lr itself so that the *caller's*
+    // return address can be recovered.
+    //
+    // In the standard calling convention, the following happens:
+    //
+    // PUSH fp, lr    (save fp and lr to the stack -- ARM64 pushes in pairs)
+    // fp := sp       (update the frame pointer to the current stack pointer)
+    // lr := pc       (save the return address in the link register)
+    //
+    // So to restore the caller's registers, we have:
+    //
+    // pc := lr
+    // sp := fp + ptr*2
+    // lr := *(fp + ptr)
+    // fp := *fp
+
+    let last_fp = ctx.get_register(FRAME_POINTER, valid)?;
+    let last_sp = ctx.get_register(STACK_POINTER, valid)?;
+    let last_lr = match ctx.get_register(LINK_REGISTER, valid) {
+        Some(lr) => lr,
+        None => {
+            // TODO: it would be good to write this back to the callee's ctx/validity
+            get_link_register_by_frame_pointer(ctx, valid, stack_memory, grand_callee_frame)?
+        }
+    };
+
+    let caller_fp = stack_memory.get_memory_at_address(last_fp as u64)?;
+    let caller_lr = stack_memory.get_memory_at_address(last_fp + POINTER_WIDTH as u64)?;
+    let caller_lr = ptr_auth_strip(caller_lr);
+    let caller_pc = last_lr;
+
+    // TODO: why does breakpad do this? How could we get this far with a null fp?
+    let caller_sp = if last_fp == 0 {
+        last_sp
+    } else {
+        last_fp + POINTER_WIDTH * 2
+    };
+
+    // Breakpad's tests don't like it we validate the frame pointer's value,
+    // so we don't check that.
+
+    // Don't accept obviously wrong instruction pointers.
+    if !instruction_seems_valid(caller_pc, modules, symbol_provider) {
+        return None;
+    }
+
+    // Don't accept obviously wrong stack pointers.
+    if !stack_seems_valid(caller_sp, last_sp, stack_memory) {
+        return None;
+    }
+
+    let mut caller_ctx = ArmContext::default();
+    caller_ctx.set_register(PROGRAM_COUNTER, caller_pc);
+    caller_ctx.set_register(LINK_REGISTER, caller_lr);
+    caller_ctx.set_register(FRAME_POINTER, caller_fp);
+    caller_ctx.set_register(STACK_POINTER, caller_sp);
+
+    let mut valid = HashSet::new();
+    valid.insert(PROGRAM_COUNTER);
+    valid.insert(LINK_REGISTER);
+    valid.insert(FRAME_POINTER);
+    valid.insert(STACK_POINTER);
+
+    let context = MinidumpContext {
+        raw: MinidumpRawContext::OldArm64(caller_ctx),
+        valid: MinidumpContextValidity::Some(valid),
+    };
+    let mut frame = StackFrame::from_context(context, FrameTrust::FramePointer);
+    adjust_instruction(&mut frame, caller_pc);
+    Some(frame)
+}
+
+/// Restores the callee's link register from the stack.
+fn get_link_register_by_frame_pointer(
+    ctx: &ArmContext,
+    valid: &MinidumpContextValidity,
+    stack_memory: &MinidumpMemory,
+    grand_callee_frame: Option<&StackFrame>,
+) -> Option<Pointer> {
+    // It may happen that whatever unwinding strategy we're using managed to
+    // restore %fp but didn't restore %lr. Frame-pointer-based unwinding requires
+    // %lr because it contains the return address (the caller's %pc).
+    //
+    // In the standard ARM64 calling convention %fp and %lr are pushed together,
+    // so if the grand-callee appears to have been called with that convention
+    // then we can recover %lr using its %fp.
+
+    // We need the grand_callee_frame's frame pointer
+    let grand_callee_frame = grand_callee_frame?;
+    let last_last_fp = if let MinidumpRawContext::OldArm64(ref ctx) = grand_callee_frame.context.raw
+    {
+        ctx.get_register(FRAME_POINTER, &grand_callee_frame.context.valid)?
+    } else {
+        return None;
+    };
+    let presumed_last_fp: Pointer = stack_memory.get_memory_at_address(last_last_fp as u64)?;
+
+    // Make sure fp and sp aren't obviously garbage (are well-ordered)
+    let last_fp = ctx.get_register(FRAME_POINTER, valid)?;
+    let last_sp = ctx.get_register(STACK_POINTER, valid)?;
+    if last_fp <= last_sp {
+        return None;
+    }
+
+    // Make sure the grand-callee and callee agree on the value of fp
+    if presumed_last_fp != last_fp {
+        return None;
+    }
+
+    // Now that we're pretty confident that frame pointers are valid, restore
+    // the callee's %lr, which should be right next to where its %fp is saved.
+    let last_lr = stack_memory.get_memory_at_address(last_last_fp + POINTER_WIDTH)?;
+
+    Some(ptr_auth_strip(last_lr))
+}
+
+fn ptr_auth_strip(ptr: Pointer) -> Pointer {
+    // TODO: attempt to remove ARM pointer authentication obfuscation
+    ptr
+}
+
+fn get_caller_by_cfi<P>(
+    ctx: &ArmContext,
+    valid: &MinidumpContextValidity,
+    _trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    grand_callee_frame: Option<&StackFrame>,
+    modules: &MinidumpModuleList,
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
+    trace!("trying to get frame by cfi");
+
+    let last_sp = ctx.get_register(STACK_POINTER, valid)?;
+    let last_pc = ctx.get_register(PROGRAM_COUNTER, valid)?;
+
+    trace!("  ...context was good");
+
+    let module = modules.module_at_address(last_pc as u64)?;
+    trace!("  ...found module");
+
+    let grand_callee_parameter_size = grand_callee_frame
+        .and_then(|f| f.parameter_size)
+        .unwrap_or(0);
+
+    let mut stack_walker = CfiStackWalker {
+        instruction: last_pc as u64,
+        grand_callee_parameter_size,
+
+        callee_ctx: ctx,
+        callee_validity: valid,
+
+        caller_ctx: ArmContext::default(),
+        caller_validity: HashSet::new(),
+
+        stack_memory,
+    };
+
+    symbol_provider.walk_frame(module, &mut stack_walker)?;
+    let caller_pc = stack_walker.caller_ctx.get_register_always(PROGRAM_COUNTER);
+    let caller_sp = stack_walker.caller_ctx.get_register_always(STACK_POINTER);
+
+    // Don't accept obviously wrong instruction pointers.
+    if !instruction_seems_valid(caller_pc, modules, symbol_provider) {
+        return None;
+    }
+    // Don't accept obviously wrong stack pointers.
+    if !stack_seems_valid(caller_sp, last_sp, stack_memory) {
+        return None;
+    }
+
+    let context = MinidumpContext {
+        raw: MinidumpRawContext::OldArm64(stack_walker.caller_ctx),
+        valid: MinidumpContextValidity::Some(stack_walker.caller_validity),
+    };
+    let mut frame = StackFrame::from_context(context, FrameTrust::CallFrameInfo);
+    adjust_instruction(&mut frame, caller_pc);
+    Some(frame)
+}
+
+fn get_caller_by_scan<P>(
+    ctx: &ArmContext,
+    valid: &MinidumpContextValidity,
+    trust: FrameTrust,
+    stack_memory: &MinidumpMemory,
+    modules: &MinidumpModuleList,
+    symbol_provider: &P,
+) -> Option<StackFrame>
+where
+    P: SymbolProvider,
+{
+    // Stack scanning is just walking from the end of the frame until we encounter
+    // a value on the stack that looks like a pointer into some code (it's an address
+    // in a range covered by one of our modules). If we find such an instruction,
+    // we assume it's an pc value that was pushed by the CALL instruction that created
+    // the current frame. The next frame is then assumed to end just before that
+    // pc value.
+    let last_sp = ctx.get_register(STACK_POINTER, valid)?;
+
+    // Number of pointer-sized values to scan through in our search.
+    let default_scan_range = 40;
+    let extended_scan_range = default_scan_range * 4;
+
+    // Breakpad devs found that the first frame of an unwind can be really messed up,
+    // and therefore benefits from a longer scan. Let's do it too.
+    let scan_range = if let FrameTrust::Context = trust {
+        extended_scan_range
+    } else {
+        default_scan_range
+    };
+
+    for i in 0..scan_range {
+        let address_of_pc = last_sp + i * POINTER_WIDTH;
+        let caller_pc = stack_memory.get_memory_at_address(address_of_pc as u64)?;
+        if instruction_seems_valid(caller_pc, modules, symbol_provider) {
+            // pc is pushed by CALL, so sp is just address_of_pc + ptr
+            let caller_sp = address_of_pc + POINTER_WIDTH;
+
+            // Don't do any more validation, and don't try to restore fp
+            // (that's what breakpad does!)
+
+            let mut caller_ctx = ArmContext::default();
+            caller_ctx.set_register(PROGRAM_COUNTER, caller_pc);
+            caller_ctx.set_register(STACK_POINTER, caller_sp);
+
+            let mut valid = HashSet::new();
+            valid.insert(PROGRAM_COUNTER);
+            valid.insert(STACK_POINTER);
+
+            let context = MinidumpContext {
+                raw: MinidumpRawContext::OldArm64(caller_ctx),
+                valid: MinidumpContextValidity::Some(valid),
+            };
+            let mut frame = StackFrame::from_context(context, FrameTrust::Scan);
+            adjust_instruction(&mut frame, caller_pc);
+            return Some(frame);
+        }
+    }
+
+    None
+}
+
+#[allow(clippy::match_like_matches_macro)]
+fn instruction_seems_valid<P>(
+    instruction: Pointer,
+    modules: &MinidumpModuleList,
+    _symbol_provider: &P,
+) -> bool
+where
+    P: SymbolProvider,
+{
+    // Reject instructions in the first page or above the user-space threshold.
+    if !(0x1000..=0x000fffffffffffff).contains(&instruction) {
+        return false;
+    }
+
+    if let Some(_module) = modules.module_at_address(instruction as u64) {
+        // TODO: if mapped, check if this instruction actually maps to a function line
+        true
+    } else {
+        false
+    }
+}
+
+fn stack_seems_valid(
+    caller_sp: Pointer,
+    callee_sp: Pointer,
+    stack_memory: &MinidumpMemory,
+) -> bool {
+    // The stack shouldn't *grow* when we unwind
+    if caller_sp <= callee_sp {
+        return false;
+    }
+
+    // The stack pointer should be in the stack
+    stack_memory
+        .get_memory_at_address::<Pointer>(caller_sp as u64)
+        .is_some()
+}
+
+fn adjust_instruction(frame: &mut StackFrame, caller_pc: Pointer) {
+    // A caller's pc is the return address, which is the instruction
+    // after the CALL that caused us to arrive at the callee. Set
+    // the value to one less than that, so it points within the
+    // CALL instruction.
+    if caller_pc > 0 {
+        frame.instruction = caller_pc as u64 - 1;
+    }
+}
+
+impl Unwind for ArmContext {
+    fn get_caller_frame<P>(
+        &self,
+        valid: &MinidumpContextValidity,
+        trust: FrameTrust,
+        stack_memory: Option<&MinidumpMemory>,
+        grand_callee_frame: Option<&StackFrame>,
+        modules: &MinidumpModuleList,
+        syms: &P,
+    ) -> Option<StackFrame>
+    where
+        P: SymbolProvider,
+    {
+        stack_memory
+            .as_ref()
+            .and_then(|stack| {
+                get_caller_by_cfi(self, valid, trust, stack, grand_callee_frame, modules, syms)
+                    .or_else(|| {
+                        get_caller_by_frame_pointer(
+                            self,
+                            valid,
+                            trust,
+                            stack,
+                            grand_callee_frame,
+                            modules,
+                            syms,
+                        )
+                    })
+                    .or_else(|| get_caller_by_scan(self, valid, trust, stack, modules, syms))
+            })
+            .and_then(|frame| {
+                // Treat an instruction address of 0 as end-of-stack.
+                if frame.context.get_instruction_pointer() == 0 {
+                    return None;
+                }
+                // If the new stack pointer is at a lower address than the old,
+                // then that's clearly incorrect. Treat this as end-of-stack to
+                // enforce progress and avoid infinite loops.
+                if frame.context.get_stack_pointer() <= self.get_register_always("sp") {
+                    return None;
+                }
+                Some(frame)
+            })
+    }
+}

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -1,0 +1,330 @@
+// Copyright 2015 Ted Mielczarek. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+
+// NOTE: we don't bother testing arm64_old, it should have identical code at
+// all times!
+
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
+use breakpad_symbols::{SimpleSymbolSupplier, Symbolizer};
+use minidump::*;
+use test_assembler::*;
+
+type Context = minidump::format::CONTEXT_ARM64;
+
+struct TestFixture {
+    pub raw: Context,
+    pub modules: MinidumpModuleList,
+    pub symbolizer: Symbolizer,
+}
+
+impl TestFixture {
+    pub fn new() -> TestFixture {
+        TestFixture {
+            raw: Context::default(),
+            // Give the two modules reasonable standard locations and names
+            // for tests to play with.
+            modules: MinidumpModuleList::from_modules(vec![
+                MinidumpModule::new(0x40000000, 0x10000, "module1"),
+                MinidumpModule::new(0x50000000, 0x10000, "module2"),
+            ]),
+            symbolizer: Symbolizer::new(SimpleSymbolSupplier::new(vec![])),
+        }
+    }
+
+    pub fn walk_stack(&self, stack: Section) -> CallStack {
+        let context = MinidumpContext {
+            raw: MinidumpRawContext::Arm64(self.raw.clone()),
+            valid: MinidumpContextValidity::All,
+        };
+        let base = stack.start().value().unwrap();
+        let size = stack.size();
+        let stack = stack.get_contents().unwrap();
+        let stack_memory = MinidumpMemory {
+            desc: Default::default(),
+            base_address: base,
+            size,
+            bytes: &stack,
+        };
+        walk_stack(
+            &Some(&context),
+            Some(&stack_memory),
+            &self.modules,
+            &self.symbolizer,
+        )
+    }
+}
+
+#[test]
+fn test_simple() {
+    let mut f = TestFixture::new();
+    let stack = Section::new();
+    stack.start().set_const(0x80000000);
+    // There should be no references to the stack in this walk: we don't
+    // provide any call frame information, so trying to reconstruct the
+    // context frame's caller should fail. So there's no need for us to
+    // provide stack contents.
+    f.raw.set_register("pc", 0x4000c020);
+    f.raw.set_register("fp", 0x80000000);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 1);
+    let f = &s.frames[0];
+    let m = f.module.as_ref().unwrap();
+    assert_eq!(m.code_file(), "module1");
+}
+
+#[test]
+fn test_scan_without_symbols() {
+    // Scanning should work without any symbols
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    stack.start().set_const(0x80000000);
+
+    let return_address1 = 0x50000100u64;
+    let return_address2 = 0x50000900u64;
+    let frame1_sp = Label::new();
+    let frame2_sp = Label::new();
+
+    stack = stack
+        // frame 0
+        .append_repeated(0, 16) // space
+        .D64(0x40090000) // junk that's not
+        .D64(0x60000000) // a return address
+        .D64(return_address1) // actual return address
+        // frame 1
+        .mark(&frame1_sp)
+        .append_repeated(0, 16) // space
+        .D64(0xF0000000) // more junk
+        .D64(0x0000000D)
+        .D64(return_address2) // actual return address
+        // frame 2
+        .mark(&frame2_sp)
+        .append_repeated(0, 64); // end of stack
+
+    f.raw.set_register("pc", 0x40005510);
+    f.raw.set_register("sp", stack.start().value().unwrap());
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 3);
+
+    {
+        // Frame 0
+        let frame = &s.frames[0];
+        assert_eq!(frame.trust, FrameTrust::Context);
+        assert_eq!(frame.context.valid, MinidumpContextValidity::All);
+    }
+
+    {
+        // Frame 1
+        let frame = &s.frames[1];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::Scan);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 2);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address1);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame1_sp.value().unwrap()
+            );
+        } else {
+            unreachable!();
+        }
+    }
+
+    {
+        // Frame 2
+        let frame = &s.frames[2];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::Scan);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 2);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address2);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame2_sp.value().unwrap()
+            );
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+#[test]
+fn test_scan_first_frame() {
+    // The first (context) frame gets extra long scans, this test checks that.
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    stack.start().set_const(0x80000000);
+
+    let return_address1 = 0x50000100u64;
+    let return_address2 = 0x50000900u64;
+    let frame1_sp = Label::new();
+    let frame2_sp = Label::new();
+
+    stack = stack
+        // frame 0
+        .append_repeated(0, 16) // space
+        .D64(0x40090000) // junk that's not
+        .D64(0x60000000) // a return address
+        .append_repeated(0, 96) // more space
+        .D64(return_address1) // actual return address
+        // frame 1
+        .mark(&frame1_sp)
+        .append_repeated(0, 32) // space
+        .D64(0xF0000000) // more junk
+        .D64(0x0000000D)
+        .append_repeated(0, 336) // more space
+        .D64(return_address2) // actual return address (won't be found)
+        // frame 2
+        .mark(&frame2_sp)
+        .append_repeated(0, 64); // end of stack
+
+    f.raw.set_register("pc", 0x40005510);
+    f.raw.set_register("sp", stack.start().value().unwrap());
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 2);
+
+    {
+        // Frame 0
+        let frame = &s.frames[0];
+        assert_eq!(frame.trust, FrameTrust::Context);
+        assert_eq!(frame.context.valid, MinidumpContextValidity::All);
+    }
+
+    {
+        // Frame 1
+        let frame = &s.frames[1];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::Scan);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 2);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address1);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame1_sp.value().unwrap()
+            );
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+#[test]
+fn test_frame_pointer() {
+    // Frame-pointer-based unwinding
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    stack.start().set_const(0x80000000);
+
+    let return_address1 = 0x50000100u64;
+    let return_address2 = 0x50000900u64;
+    let frame1_sp = Label::new();
+    let frame2_sp = Label::new();
+    let frame1_fp = Label::new();
+    let frame2_fp = Label::new();
+
+    stack = stack
+        // frame 0
+        .append_repeated(0, 64) // space
+        .D64(0x0000000D) // junk that's not
+        .D64(0xF0000000) // a return address
+        .mark(&frame1_fp) // next fp will point to the next value
+        .D64(&frame2_fp) // save current frame pointer
+        .D64(return_address2) // save current link register
+        .mark(&frame1_sp)
+        // frame 1
+        .append_repeated(0, 64) // space
+        .D64(0x0000000D) // junk that's not
+        .D64(0xF0000000) // a return address
+        .mark(&frame2_fp)
+        .D64(0)
+        .D64(0)
+        .mark(&frame2_sp)
+        // frame 2
+        .append_repeated(0, 64) // Whatever values on the stack.
+        .D64(0x0000000D) // junk that's not
+        .D64(0xF0000000); // a return address.
+
+    f.raw.set_register("pc", 0x40005510);
+    f.raw.set_register("lr", return_address1);
+    f.raw.set_register("fp", frame1_fp.value().unwrap());
+    f.raw.set_register("sp", stack.start().value().unwrap());
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 3);
+
+    {
+        // Frame 0
+        let frame = &s.frames[0];
+        assert_eq!(frame.trust, FrameTrust::Context);
+        assert_eq!(frame.context.valid, MinidumpContextValidity::All);
+    }
+
+    {
+        // Frame 1
+        let frame = &s.frames[1];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::FramePointer);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 4);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address1);
+            assert_eq!(ctx.get_register("lr", valid).unwrap(), return_address2);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame1_sp.value().unwrap()
+            );
+            assert_eq!(
+                ctx.get_register("fp", valid).unwrap(),
+                frame2_fp.value().unwrap()
+            );
+        } else {
+            unreachable!();
+        }
+    }
+
+    {
+        // Frame 2
+        let frame = &s.frames[2];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::FramePointer);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 4);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address2);
+            assert_eq!(ctx.get_register("lr", valid).unwrap(), 0);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame2_sp.value().unwrap()
+            );
+            assert_eq!(ctx.get_register("fp", valid).unwrap(), 0);
+        } else {
+            unreachable!();
+        }
+    }
+}

--- a/minidump-processor/src/stackwalker/arm_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm_unittest.rs
@@ -1,0 +1,332 @@
+// Copyright 2015 Ted Mielczarek. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+
+// NOTE: we don't bother testing arm64_old, it should have identical code at
+// all times!
+
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
+use breakpad_symbols::{SimpleSymbolSupplier, Symbolizer};
+use minidump::format::CONTEXT_ARM;
+use minidump::*;
+use test_assembler::*;
+
+struct TestFixture {
+    pub raw: CONTEXT_ARM,
+    pub modules: MinidumpModuleList,
+    pub symbolizer: Symbolizer,
+}
+
+impl TestFixture {
+    pub fn new() -> TestFixture {
+        TestFixture {
+            raw: CONTEXT_ARM::default(),
+            // Give the two modules reasonable standard locations and names
+            // for tests to play with.
+            modules: MinidumpModuleList::from_modules(vec![
+                MinidumpModule::new(0x40000000, 0x10000, "module1"),
+                MinidumpModule::new(0x50000000, 0x10000, "module2"),
+            ]),
+            symbolizer: Symbolizer::new(SimpleSymbolSupplier::new(vec![])),
+        }
+    }
+
+    pub fn walk_stack(&self, stack: Section) -> CallStack {
+        let context = MinidumpContext {
+            raw: MinidumpRawContext::Arm(self.raw.clone()),
+            valid: MinidumpContextValidity::All,
+        };
+        let base = stack.start().value().unwrap();
+        let size = stack.size();
+        let stack = stack.get_contents().unwrap();
+        let stack_memory = MinidumpMemory {
+            desc: Default::default(),
+            base_address: base,
+            size,
+            bytes: &stack,
+        };
+        walk_stack(
+            &Some(&context),
+            Some(&stack_memory),
+            &self.modules,
+            &self.symbolizer,
+        )
+    }
+}
+
+#[test]
+fn test_simple() {
+    let mut f = TestFixture::new();
+    let stack = Section::new();
+    stack.start().set_const(0x80000000);
+    // There should be no references to the stack in this walk: we don't
+    // provide any call frame information, so trying to reconstruct the
+    // context frame's caller should fail. So there's no need for us to
+    // provide stack contents.
+    f.raw.set_register("pc", 0x4000c020);
+    f.raw.set_register("fp", 0x80000000);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 1);
+    let f = &s.frames[0];
+    let m = f.module.as_ref().unwrap();
+    assert_eq!(m.code_file(), "module1");
+}
+
+#[test]
+fn test_scan_without_symbols() {
+    // Scanning should work without any symbols
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    stack.start().set_const(0x80000000);
+
+    let return_address1 = 0x50000100u32;
+    let return_address2 = 0x50000900u32;
+    let frame1_sp = Label::new();
+    let frame2_sp = Label::new();
+
+    stack = stack
+        // frame 0
+        .append_repeated(0, 16) // space
+        .D32(0x40090000) // junk that's not
+        .D32(0x60000000) // a return address
+        .D32(return_address1) // actual return address
+        // frame 1
+        .mark(&frame1_sp)
+        .append_repeated(0, 16) // space
+        .D32(0xF0000000) // more junk
+        .D32(0x0000000D)
+        .D32(return_address2) // actual return address
+        // frame 2
+        .mark(&frame2_sp)
+        .append_repeated(0, 32); // end of stack
+
+    f.raw.set_register("pc", 0x40005510);
+    f.raw
+        .set_register("sp", stack.start().value().unwrap() as u32);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 3);
+
+    {
+        // Frame 0
+        let frame = &s.frames[0];
+        assert_eq!(frame.trust, FrameTrust::Context);
+        assert_eq!(frame.context.valid, MinidumpContextValidity::All);
+    }
+
+    {
+        // Frame 1
+        let frame = &s.frames[1];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::Scan);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 2);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address1);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame1_sp.value().unwrap() as u32
+            );
+        } else {
+            unreachable!();
+        }
+    }
+
+    {
+        // Frame 2
+        let frame = &s.frames[2];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::Scan);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 2);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address2);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame2_sp.value().unwrap() as u32
+            );
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+#[test]
+fn test_scan_first_frame() {
+    // The first (context) frame gets extra long scans, this test checks that.
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    stack.start().set_const(0x80000000);
+
+    let return_address1 = 0x50000100u32;
+    let return_address2 = 0x50000900u32;
+    let frame1_sp = Label::new();
+    let frame2_sp = Label::new();
+
+    stack = stack
+        // frame 0
+        .append_repeated(0, 16) // space
+        .D32(0x40090000) // junk that's not
+        .D32(0x60000000) // a return address
+        .append_repeated(0, 96) // more space
+        .D32(return_address1) // actual return address
+        // frame 1
+        .mark(&frame1_sp)
+        .append_repeated(0, 32) // space
+        .D32(0xF0000000) // more junk
+        .D32(0x0000000D)
+        .append_repeated(0, 336) // more space
+        .D32(return_address2) // actual return address (won't be found)
+        // frame 2
+        .mark(&frame2_sp)
+        .append_repeated(0, 64); // end of stack
+
+    f.raw.set_register("pc", 0x40005510);
+    f.raw
+        .set_register("sp", stack.start().value().unwrap() as u32);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 2);
+
+    {
+        // Frame 0
+        let frame = &s.frames[0];
+        assert_eq!(frame.trust, FrameTrust::Context);
+        assert_eq!(frame.context.valid, MinidumpContextValidity::All);
+    }
+
+    {
+        // Frame 1
+        let frame = &s.frames[1];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::Scan);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 2);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address1);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame1_sp.value().unwrap() as u32
+            );
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+#[test]
+fn test_frame_pointer() {
+    // Frame-pointer-based unwinding
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    stack.start().set_const(0x80000000);
+
+    let return_address1 = 0x50000100u32;
+    let return_address2 = 0x50000900u32;
+    let frame1_sp = Label::new();
+    let frame2_sp = Label::new();
+    let frame1_fp = Label::new();
+    let frame2_fp = Label::new();
+
+    stack = stack
+        // frame 0
+        .append_repeated(0, 32) // space
+        .D32(0x0000000D) // junk that's not
+        .D32(0xF0000000) // a return address
+        .mark(&frame1_fp) // next fp will point to the next value
+        .D32(&frame2_fp) // save current frame pointer
+        .D32(return_address2) // save current link register
+        .mark(&frame1_sp)
+        // frame 1
+        .append_repeated(0, 32) // space
+        .D32(0x0000000D) // junk that's not
+        .D32(0xF0000000) // a return address
+        .mark(&frame2_fp)
+        .D32(0)
+        .D32(0)
+        .mark(&frame2_sp)
+        // frame 2
+        .append_repeated(0, 32) // Whatever values on the stack.
+        .D32(0x0000000D) // junk that's not
+        .D32(0xF0000000); // a return address.
+
+    f.raw.set_register("pc", 0x40005510);
+    f.raw.set_register("lr", return_address1);
+    f.raw.set_register("fp", frame1_fp.value().unwrap() as u32);
+    f.raw
+        .set_register("sp", stack.start().value().unwrap() as u32);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 3);
+
+    {
+        // Frame 0
+        let frame = &s.frames[0];
+        assert_eq!(frame.trust, FrameTrust::Context);
+        assert_eq!(frame.context.valid, MinidumpContextValidity::All);
+    }
+
+    {
+        // Frame 1
+        let frame = &s.frames[1];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::FramePointer);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 4);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address1);
+            assert_eq!(ctx.get_register("lr", valid).unwrap(), return_address2);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame1_sp.value().unwrap() as u32
+            );
+            assert_eq!(
+                ctx.get_register("fp", valid).unwrap(),
+                frame2_fp.value().unwrap() as u32
+            );
+        } else {
+            unreachable!();
+        }
+    }
+
+    {
+        // Frame 2
+        let frame = &s.frames[2];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::FramePointer);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 4);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address2);
+            assert_eq!(ctx.get_register("lr", valid).unwrap(), 0);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame2_sp.value().unwrap() as u32
+            );
+            assert_eq!(ctx.get_register("fp", valid).unwrap(), 0);
+        } else {
+            unreachable!();
+        }
+    }
+}

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -4,6 +4,9 @@
 //! Unwind stack frames for a thread.
 
 mod amd64;
+mod arm;
+mod arm64;
+mod arm64_old;
 mod unwind;
 mod x86;
 
@@ -86,13 +89,35 @@ where
 {
     match callee_frame.context.raw {
         /*
-        MinidumpRawContext::ARM(ctx) => ctx.get_caller_frame(stack_memory),
-        MinidumpRawContext::ARM64(ctx) => ctx.get_caller_frame(stack_memory),
         MinidumpRawContext::PPC(ctx) => ctx.get_caller_frame(stack_memory),
         MinidumpRawContext::PPC64(ctx) => ctx.get_caller_frame(stack_memory),
         MinidumpRawContext::SPARC(ctx) => ctx.get_caller_frame(stack_memory),
         MinidumpRawContext::MIPS(ctx) => ctx.get_caller_frame(stack_memory),
          */
+        MinidumpRawContext::Arm(ref ctx) => ctx.get_caller_frame(
+            &callee_frame.context.valid,
+            callee_frame.trust,
+            stack_memory,
+            grand_callee_frame,
+            modules,
+            symbol_provider,
+        ),
+        MinidumpRawContext::Arm64(ref ctx) => ctx.get_caller_frame(
+            &callee_frame.context.valid,
+            callee_frame.trust,
+            stack_memory,
+            grand_callee_frame,
+            modules,
+            symbol_provider,
+        ),
+        MinidumpRawContext::OldArm64(ref ctx) => ctx.get_caller_frame(
+            &callee_frame.context.valid,
+            callee_frame.trust,
+            stack_memory,
+            grand_callee_frame,
+            modules,
+            symbol_provider,
+        ),
         MinidumpRawContext::Amd64(ref ctx) => ctx.get_caller_frame(
             &callee_frame.context.valid,
             callee_frame.trust,
@@ -170,5 +195,9 @@ where
 
 #[cfg(test)]
 mod amd64_unittest;
+#[cfg(test)]
+mod arm64_unittest;
+#[cfg(test)]
+mod arm_unittest;
 #[cfg(test)]
 mod x86_unittest;

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -689,8 +689,14 @@ impl MinidumpModule {
         Ok(())
     }
 
-    fn memory_range(&self) -> Range<u64> {
-        Range::new(self.base_address(), self.base_address() + self.size() - 1)
+    fn memory_range(&self) -> Option<Range<u64>> {
+        if self.size() == 0 {
+            return None;
+        }
+        Some(Range::new(
+            self.base_address(),
+            self.base_address().checked_add(self.size())? - 1,
+        ))
     }
 }
 
@@ -831,8 +837,14 @@ impl MinidumpUnloadedModule {
         Ok(())
     }
 
-    fn memory_range(&self) -> Range<u64> {
-        Range::new(self.base_address(), self.base_address() + self.size() - 1)
+    fn memory_range(&self) -> Option<Range<u64>> {
+        if self.size() == 0 {
+            return None;
+        }
+        Some(Range::new(
+            self.base_address(),
+            self.base_address().checked_add(self.size())? - 1,
+        ))
     }
 }
 
@@ -1281,8 +1293,14 @@ Memory
         Ok(())
     }
 
-    fn memory_range(&self) -> Range<u64> {
-        Range::new(self.base_address, self.base_address + self.size - 1)
+    fn memory_range(&self) -> Option<Range<u64>> {
+        if self.size == 0 {
+            return None;
+        }
+        Some(Range::new(
+            self.base_address,
+            self.base_address.checked_add(self.size)? - 1,
+        ))
     }
 }
 


### PR DESCRIPTION
The code for all 3 is identical for now. I'm pretty sure the framepointer/scan code is wrong for 32-bit ARM, to be iterated on more later. I added the 32-bit ARM stuff as a bit of an afterthought when I encountered it while testing on some firefox minidumps.

This also includes two commits that fixup other stuff I ran into while testing these.