### PR TITLE
Make a shim for toggling between breakpad and symbolic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,6 @@ name = "minidump-stackwalk"
 version = "0.3.0"
 dependencies = [
  "addr2line 0.15.2",
- "breakpad-symbols",
  "clap",
  "log",
  "minidump",

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -243,20 +243,8 @@ pub struct StringSymbolSupplier {
 
 impl StringSymbolSupplier {
     /// Make a new StringSymbolSupplier with no modules.
-    pub fn new() -> Self {
-        Self {
-            modules: HashMap::new(),
-        }
-    }
-
-    /// Add a symbol file.
-    pub fn insert(&mut self, code_file: String, symbols: String) {
-        self.modules.insert(code_file, symbols);
-    }
-
-    /// Remove all symbol files.
-    pub fn clear(&mut self) {
-        self.modules.clear();
+    pub fn new(modules: HashMap<String, String>) -> Self {
+        Self { modules }
     }
 }
 

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -13,9 +13,16 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "luser/rust-minidump" }
 
+[features]
+default = ["breakpad-syms"]
+# Use the `breakpad-symbols` crate for symbolizing and cfi evaluation
+breakpad-syms = ["breakpad-symbols"]
+# Use the `symbolic` crate for symbolizing and cfi evaluation (TODO)
+symbolic-syms = []
+
 [dependencies]
 addr2line = "0.15.2"
-breakpad-symbols = { version = "0.3.0", path = "../breakpad-symbols" }
+breakpad-symbols = { version = "0.3.0", path = "../breakpad-symbols", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
 clap = "2.33"
 failure = "0.1.1"

--- a/minidump-processor/src/dwarf_symbolizer.rs
+++ b/minidump-processor/src/dwarf_symbolizer.rs
@@ -7,10 +7,9 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::File;
 
-use breakpad_symbols::{FrameSymbolizer, FrameWalker};
 use minidump::Module;
 
-use crate::SymbolProvider;
+use crate::{FrameSymbolizer, FrameWalker, SymbolProvider};
 
 #[derive(Default)]
 pub struct DwarfSymbolizer {

--- a/minidump-processor/src/lib.rs
+++ b/minidump-processor/src/lib.rs
@@ -10,10 +10,12 @@ mod dwarf_symbolizer;
 mod process_state;
 mod processor;
 mod stackwalker;
+mod symbols;
 mod system_info;
 
 pub use crate::dwarf_symbolizer::DwarfSymbolizer;
 pub use crate::process_state::*;
 pub use crate::processor::*;
 pub use crate::stackwalker::*;
+pub use crate::symbols::*;
 pub use crate::system_info::*;

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -9,7 +9,7 @@ use std::io;
 use std::io::prelude::*;
 
 use crate::system_info::SystemInfo;
-use breakpad_symbols::FrameSymbolizer;
+use crate::FrameSymbolizer;
 use chrono::prelude::*;
 use minidump::system_info::Cpu;
 use minidump::*;

--- a/minidump-processor/src/stackwalker/amd64_unittest.rs
+++ b/minidump-processor/src/stackwalker/amd64_unittest.rs
@@ -3,15 +3,16 @@
 
 use crate::process_state::*;
 use crate::stackwalker::walk_stack;
-use breakpad_symbols::{SimpleSymbolSupplier, Symbolizer};
+use crate::{string_symbol_supplier, Symbolizer};
 use minidump::format::CONTEXT_AMD64;
 use minidump::*;
+use std::collections::HashMap;
 use test_assembler::*;
 
 struct TestFixture {
     pub raw: CONTEXT_AMD64,
     pub modules: MinidumpModuleList,
-    pub symbolizer: Symbolizer,
+    pub symbols: HashMap<String, String>,
 }
 
 impl TestFixture {
@@ -24,7 +25,7 @@ impl TestFixture {
                 MinidumpModule::new(0x00007400c0000000, 0x10000, "module1"),
                 MinidumpModule::new(0x00007500b0000000, 0x10000, "module2"),
             ]),
-            symbolizer: Symbolizer::new(SimpleSymbolSupplier::new(vec![])),
+            symbols: HashMap::new(),
         }
     }
 
@@ -42,13 +43,20 @@ impl TestFixture {
             size,
             bytes: &stack,
         };
+        let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
         walk_stack(
             &Some(&context),
             Some(&stack_memory),
             &self.modules,
-            &self.symbolizer,
+            &symbolizer,
         )
     }
+
+    /*
+        pub fn add_symbols(&mut self, name: String, symbols: String) {
+            self.symbols.insert(name, symbols);
+        }
+    */
 }
 
 #[test]
@@ -234,71 +242,3 @@ fn test_scan_without_symbols() {
         }
     }
 }
-
-/*
-// Walk a traditional frame. A traditional frame saves the caller's
-// %ebp just below the return address, and has its own %ebp pointing
-// at the saved %ebp.
-#[test]
-fn test_traditional() {
-    let mut f = TestFixture::new();
-   let frame0_rbp = Label::new();
-   let frame1_rbp = Label::new();
-   let mut stack = Section::new();
-   let stack_start = 0x80000000;
-    stack.start().set_const(stack_start);
-
-  stack = stack
-    .append_repeated(12, 0)                      // frame 0: space
-    .mark(&frame0_ebp)                  // frame 0 %ebp points here
-    .D32(&frame1_ebp)                    // frame 0: saved %ebp
-    .D32(0x40008679)                    // frame 0: return address
-    .append_repeated(8, 0)                       // frame 1: space
-    .mark(&frame1_ebp)                  // frame 1 %ebp points here
-    .D32(0)                             // frame 1: saved %ebp (stack end)
-    .D32(0);                            // frame 1: return address (stack end)
-
-  f.raw.eip = 0x4000c7a5;
-  f.raw.esp = stack.start().value().unwrap();
-  f.raw.ebp = frame0_ebp.value().unwrap();
-
-  let s = f.walk_stack(stack);
-  assert_eq!(s.frames.len(), 2);
-
-
-  {  // To avoid reusing locals by mistake
-    let f0 = &s.frames[0];
-            let f0 = &s.frames[0];
-        assert_eq!(f0.trust, FrameTrust::Context);
-        assert_eq!(f0.context.valid, MinidumpContextValidity::All);
-        assert_eq!(f0.instruction, 0x4000c7a5);
-        if let MinidumpRawContext::AMD64(ctx) = &f0.context.raw {
-            assert_eq!(ctx.rip, 0x4000c7a5);
-            assert_eq!(ctx.rsp, stack_start as u32);
-            assert_eq!(ctx.rbp, frame0_rbp.value().unwrap());
-        } else {
-            unreachable!();
-        }
-  }
-
-  {  // To avoid reusing locals by mistake
-    let f1 = &s.frames[1];
-    assert_eq!(f1.trust, FrameTrust::FramePointer);
-    if let MinidumpContextValidity::Some(ref which) = f1.context.valid {
-        assert!(which.contains("rip"));
-        assert!(which.contains("rsp"));
-        assert!(which.contains("rbp"));
-    } else {
-        unreachable!();
-    }
-    assert_eq!(f1.instruction + 1, 0x40008679);
-
-    if let MinidumpRawContext::AMD64(ctx) = &f1.context.raw {
-        assert_eq!(ctx.rip, 0x40008679);
-        assert_eq!(ctx.rbp, frame1_rbp.value().unwrap());
-    } else {
-        unreachable!();
-    }
-  }
-}
-*/

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -6,8 +6,9 @@
 
 use crate::process_state::*;
 use crate::stackwalker::walk_stack;
-use breakpad_symbols::{StringSymbolSupplier, Symbolizer};
+use crate::{string_symbol_supplier, Symbolizer};
 use minidump::*;
+use std::collections::HashMap;
 use test_assembler::*;
 
 type Context = minidump::format::CONTEXT_ARM64;
@@ -15,7 +16,7 @@ type Context = minidump::format::CONTEXT_ARM64;
 struct TestFixture {
     pub raw: Context,
     pub modules: MinidumpModuleList,
-    pub symbols: StringSymbolSupplier,
+    pub symbols: HashMap<String, String>,
 }
 
 impl TestFixture {
@@ -28,7 +29,7 @@ impl TestFixture {
                 MinidumpModule::new(0x40000000, 0x10000, "module1"),
                 MinidumpModule::new(0x50000000, 0x10000, "module2"),
             ]),
-            symbols: StringSymbolSupplier::new(),
+            symbols: HashMap::new(),
         }
     }
 
@@ -46,7 +47,7 @@ impl TestFixture {
             size,
             bytes: &stack,
         };
-        let symbolizer = Symbolizer::new(self.symbols.clone());
+        let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
         walk_stack(
             &Some(&context),
             Some(&stack_memory),

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -11,12 +11,11 @@ mod unwind;
 mod x86;
 
 use crate::process_state::*;
-use crate::SymbolProvider;
+use crate::{FrameWalker, SymbolProvider};
 use minidump::*;
 use scroll::ctx::{SizeWith, TryFromCtx};
 
 use self::unwind::Unwind;
-use breakpad_symbols::FrameWalker;
 use std::collections::HashSet;
 use std::convert::TryFrom;
 

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -3,15 +3,16 @@
 
 use crate::process_state::*;
 use crate::stackwalker::walk_stack;
-use breakpad_symbols::{SimpleSymbolSupplier, Symbolizer};
+use crate::{string_symbol_supplier, Symbolizer};
 use minidump::format::CONTEXT_X86;
 use minidump::*;
+use std::collections::HashMap;
 use test_assembler::*;
 
 struct TestFixture {
     pub raw: CONTEXT_X86,
     pub modules: MinidumpModuleList,
-    pub symbolizer: Symbolizer,
+    pub symbols: HashMap<String, String>,
 }
 
 impl TestFixture {
@@ -24,7 +25,7 @@ impl TestFixture {
                 MinidumpModule::new(0x40000000, 0x10000, "module1"),
                 MinidumpModule::new(0x50000000, 0x10000, "module2"),
             ]),
-            symbolizer: Symbolizer::new(SimpleSymbolSupplier::new(vec![])),
+            symbols: HashMap::new(),
         }
     }
 
@@ -42,13 +43,20 @@ impl TestFixture {
             size,
             bytes: &stack,
         };
+        let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
         walk_stack(
             &Some(&context),
             Some(&stack_memory),
             &self.modules,
-            &self.symbolizer,
+            &symbolizer,
         )
     }
+
+    /*
+        pub fn add_symbols(&mut self, name: String, symbols: String) {
+            self.symbols.insert(name, symbols);
+        }
+    */
 }
 
 #[test]

--- a/minidump-processor/src/symbols.rs
+++ b/minidump-processor/src/symbols.rs
@@ -1,0 +1,224 @@
+use minidump::Module;
+pub use symbols_shim::*;
+
+pub trait SymbolProvider {
+    fn fill_symbol(&self, module: &dyn Module, frame: &mut dyn FrameSymbolizer);
+    fn walk_frame(&self, module: &dyn Module, walker: &mut dyn FrameWalker) -> Option<()>;
+}
+
+#[derive(Default)]
+pub struct MultiSymbolProvider {
+    providers: Vec<Box<dyn SymbolProvider>>,
+}
+
+impl MultiSymbolProvider {
+    pub fn new() -> MultiSymbolProvider {
+        Default::default()
+    }
+
+    pub fn add(&mut self, provider: Box<dyn SymbolProvider>) {
+        self.providers.push(provider);
+    }
+}
+
+impl SymbolProvider for MultiSymbolProvider {
+    fn fill_symbol(&self, module: &dyn Module, frame: &mut dyn FrameSymbolizer) {
+        for p in self.providers.iter() {
+            p.fill_symbol(module, frame);
+        }
+    }
+
+    fn walk_frame(&self, module: &dyn Module, walker: &mut dyn FrameWalker) -> Option<()> {
+        for p in self.providers.iter() {
+            let result = p.walk_frame(module, walker);
+            if result.is_some() {
+                return result;
+            }
+        }
+        None
+    }
+}
+
+#[cfg(feature = "breakpad-syms")]
+mod symbols_shim {
+    use super::SymbolProvider;
+    use minidump::Module;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    pub use breakpad_symbols::{FrameSymbolizer, FrameWalker, SymbolSupplier, Symbolizer};
+
+    impl SymbolProvider for Symbolizer {
+        fn fill_symbol(&self, module: &dyn Module, frame: &mut dyn FrameSymbolizer) {
+            self.fill_symbol(module, frame);
+        }
+        fn walk_frame(&self, module: &dyn Module, walker: &mut dyn FrameWalker) -> Option<()> {
+            self.walk_frame(module, walker)
+        }
+    }
+
+    /// Gets a SymbolSupplier that looks up symbols by path or with urls.
+    ///
+    /// May use the `symbols_cache` path to store downloads.
+    pub fn http_symbol_supplier(
+        symbol_paths: Vec<PathBuf>,
+        symbol_urls: Vec<String>,
+        symbols_cache: PathBuf,
+    ) -> impl SymbolSupplier {
+        breakpad_symbols::HttpSymbolSupplier::new(symbol_urls, symbols_cache, symbol_paths)
+    }
+
+    /// Gets a SymbolSupplier that looks up symbols by path.
+    pub fn simple_symbol_supplier(symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier {
+        breakpad_symbols::SimpleSymbolSupplier::new(symbol_paths)
+    }
+
+    /// Gets a mock SymbolSupplier that just maps module names
+    /// to a string containing an entire breakpad .sym file, for tests.
+    pub fn string_symbol_supplier(modules: HashMap<String, String>) -> impl SymbolSupplier {
+        breakpad_symbols::StringSymbolSupplier::new(modules)
+    }
+}
+
+#[cfg(feature = "symbolic-syms")]
+mod symbols_shim {
+    #![allow(dead_code)]
+
+    use super::SymbolProvider;
+    use minidump::Module;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    // Import symbolic here
+
+    /// A trait for things that can locate symbols for a given module.
+    pub trait SymbolSupplier {
+        /// Locate and load a symbol file for `module`.
+        ///
+        /// Implementations may use any strategy for locating and loading
+        /// symbols.
+        fn locate_symbols(&self, module: &dyn Module) -> SymbolResult;
+    }
+
+    /// A trait for setting symbol information on something like a stack frame.
+    pub trait FrameSymbolizer {
+        /// Get the program counter value for this frame.
+        fn get_instruction(&self) -> u64;
+        /// Set the name, base address, and paramter size of the function in
+        // which this frame is executing.
+        fn set_function(&mut self, name: &str, base: u64, parameter_size: u32);
+        /// Set the source file and (1-based) line number this frame represents.
+        fn set_source_file(&mut self, file: &str, line: u32, base: u64);
+    }
+
+    pub trait FrameWalker {
+        /// Get the instruction address that we're trying to unwind from.
+        fn get_instruction(&self) -> u64;
+        /// Get the number of bytes the callee's callee's parameters take up
+        /// on the stack (or 0 if unknown/invalid). This is needed for
+        /// STACK WIN unwinding.
+        fn get_grand_callee_parameter_size(&self) -> u32;
+        /// Get a register-sized value stored at this address.
+        fn get_register_at_address(&self, address: u64) -> Option<u64>;
+        /// Get the value of a register from the callee's frame.
+        fn get_callee_register(&self, name: &str) -> Option<u64>;
+        /// Set the value of a register for the caller's frame.
+        fn set_caller_register(&mut self, name: &str, val: u64) -> Option<()>;
+        /// Set whatever registers in the caller should be set based on the cfa (e.g. rsp).
+        fn set_cfa(&mut self, val: u64) -> Option<()>;
+        /// Set whatever registers in the caller should be set based on the return address (e.g. rip).
+        fn set_ra(&mut self, val: u64) -> Option<()>;
+    }
+
+    /// Possible results of locating symbols. (can be opaque, not used externally)
+    #[derive(Debug)]
+    pub struct SymbolResult;
+
+    /// Symbolicate stack frames.
+    ///
+    /// A `Symbolizer` manages loading symbols and looking up symbols in them
+    /// including caching so that symbols for a given module are only loaded once.
+    ///
+    /// Call [`Symbolizer::new`][new] to instantiate a `Symbolizer`. A Symbolizer
+    /// requires a [`SymbolSupplier`][supplier] to locate symbols. If you have
+    /// symbols on disk in the [customary directory layout][dirlayout], a
+    /// [`SimpleSymbolSupplier`][simple] will work.
+    ///
+    /// Use [`get_symbol_at_address`][get_symbol] or [`fill_symbol`][fill_symbol] to
+    /// do symbol lookup.
+    ///
+    /// [new]: struct.Symbolizer.html#method.new
+    /// [supplier]: trait.SymbolSupplier.html
+    /// [dirlayout]: fn.relative_symbol_path.html
+    /// [simple]: struct.SimpleSymbolSupplier.html
+    /// [get_symbol]: struct.Symbolizer.html#method.get_symbol_at_address
+    /// [fill_symbol]: struct.Symbolizer.html#method.fill_symbol
+    pub struct Symbolizer {
+        /// Symbol supplier for locating symbols.
+        supplier: Box<dyn SymbolSupplier + 'static>,
+    }
+
+    impl Symbolizer {
+        /// Create a `Symbolizer` that uses `supplier` to locate symbols.
+        pub fn new<T: SymbolSupplier + 'static>(supplier: T) -> Symbolizer {
+            Symbolizer {
+                supplier: Box::new(supplier),
+            }
+        }
+    }
+
+    impl SymbolProvider for Symbolizer {
+        fn fill_symbol(&self, _module: &dyn Module, _frame: &mut dyn FrameSymbolizer) {
+            unimplemented!()
+        }
+        fn walk_frame(&self, _module: &dyn Module, _walker: &mut dyn FrameWalker) -> Option<()> {
+            unimplemented!()
+        }
+    }
+
+    pub struct HttpSymbolSupplier {}
+
+    pub struct SimpleSymbolSupplier {}
+
+    pub struct StringSymbolSupplier {}
+
+    impl SymbolSupplier for HttpSymbolSupplier {
+        fn locate_symbols(&self, _module: &dyn Module) -> SymbolResult {
+            unimplemented!()
+        }
+    }
+
+    impl SymbolSupplier for SimpleSymbolSupplier {
+        fn locate_symbols(&self, _module: &dyn Module) -> SymbolResult {
+            unimplemented!()
+        }
+    }
+
+    impl SymbolSupplier for StringSymbolSupplier {
+        fn locate_symbols(&self, _module: &dyn Module) -> SymbolResult {
+            unimplemented!()
+        }
+    }
+
+    /// Gets a SymbolSupplier that looks up symbols by path or with urls.
+    ///
+    /// May use the `symbols_cache` path to store downloads.
+    pub fn http_symbol_supplier(
+        _symbol_paths: Vec<PathBuf>,
+        _symbol_urls: Vec<String>,
+        _symbols_cache: PathBuf,
+    ) -> impl SymbolSupplier {
+        HttpSymbolSupplier {}
+    }
+
+    /// Gets a SymbolSupplier that looks up symbols by path.
+    pub fn simple_symbol_supplier(_symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier {
+        SimpleSymbolSupplier {}
+    }
+
+    /// Gets a mock SymbolSupplier that just maps module names
+    /// to a string containing an entire breakpad .sym file, for tests.
+    pub fn string_symbol_supplier(_modules: HashMap<String, String>) -> impl SymbolSupplier {
+        StringSymbolSupplier {}
+    }
+}

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -1,10 +1,9 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use breakpad_symbols::{SimpleSymbolSupplier, Symbolizer};
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
-use minidump_processor::{CallStackInfo, FrameTrust};
+use minidump_processor::{simple_symbol_supplier, CallStackInfo, FrameTrust, Symbolizer};
 use std::path::{Path, PathBuf};
 
 fn locate_testdata() -> PathBuf {
@@ -43,7 +42,7 @@ fn test_processor() {
     let dump = read_test_minidump().unwrap();
     let state = minidump_processor::process_minidump(
         &dump,
-        &Symbolizer::new(SimpleSymbolSupplier::new(vec![])),
+        &Symbolizer::new(simple_symbol_supplier(vec![])),
     )
     .unwrap();
     assert_eq!(state.system_info.os, Os::Windows);
@@ -116,7 +115,7 @@ fn test_processor_symbols() {
     println!("symbol path: {:?}", path);
     let state = minidump_processor::process_minidump(
         &dump,
-        &Symbolizer::new(SimpleSymbolSupplier::new(vec![path])),
+        &Symbolizer::new(simple_symbol_supplier(vec![path])),
     )
     .unwrap();
     let f0 = &state.threads[0].frames[0];

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -17,7 +17,6 @@ travis-ci = { repository = "luser/rust-minidump" }
 
 [dependencies]
 addr2line = "0.15.2"
-breakpad-symbols = { version = "0.3.0", path = "../breakpad-symbols" }
 clap = "2.33"
 log = "0.4"
 minidump = { version = "0.3.0", path = "../minidump" }

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -8,9 +8,10 @@ use std::panic;
 use std::path::Path;
 use std::path::PathBuf;
 
-use breakpad_symbols::{HttpSymbolSupplier, SimpleSymbolSupplier, Symbolizer};
 use minidump::*;
-use minidump_processor::{DwarfSymbolizer, MultiSymbolProvider};
+use minidump_processor::{
+    http_symbol_supplier, simple_symbol_supplier, DwarfSymbolizer, MultiSymbolProvider, Symbolizer,
+};
 
 use clap::{crate_authors, crate_version, App, Arg};
 use log::error;
@@ -28,13 +29,13 @@ fn print_minidump_process(
         let mut provider = MultiSymbolProvider::new();
 
         if let Some(symbols_cache) = symbols_cache {
-            provider.add(Box::new(Symbolizer::new(HttpSymbolSupplier::new(
+            provider.add(Box::new(Symbolizer::new(http_symbol_supplier(
+                symbol_paths,
                 symbol_urls,
                 symbols_cache,
-                symbol_paths,
             ))));
         } else if !symbol_paths.is_empty() {
-            provider.add(Box::new(Symbolizer::new(SimpleSymbolSupplier::new(
+            provider.add(Box::new(Symbolizer::new(simple_symbol_supplier(
                 symbol_paths,
             ))));
         }


### PR DESCRIPTION
To test the symbolic mode I recommend just flipping the "default-features" value in minidump-processor's Cargo.toml