### PR TITLE
Add support for reporting unknown/unimplemented streams

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -240,6 +240,10 @@ pub enum MINIDUMP_STREAM_TYPE {
     ///
     /// See [`MinidumpCrashpadInfo`](struct.MinidumpCrashpadInfo.html).
     CrashpadInfoStream = 0x43500001,
+
+    /// Data from the __DATA,__crash_info section of every module which contains
+    /// one that has useful data. Only available on macOS. 0x4D7A = "Mz".
+    MozMacosCrashInfoStream = 0x4d7a0001,
 }
 
 impl From<MINIDUMP_STREAM_TYPE> for u32 {

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -168,6 +168,8 @@ pub struct ProcessState {
     // modules_without_symbols
     // modules_with_corrupt_symbols
     // exploitability
+    pub unknown_streams: Vec<MinidumpUnknownStream>,
+    pub unimplemented_streams: Vec<MinidumpUnimplementedStream>,
 }
 
 impl FrameTrust {
@@ -489,6 +491,39 @@ Unloaded modules:
                 module.base_address() + module.size() - 1,
                 basename(&module.code_file()),
             )?;
+        }
+        if !self.unimplemented_streams.is_empty() {
+            write!(
+                f,
+                "
+Unimplemented streams encountered:
+"
+            )?;
+            for stream in &self.unimplemented_streams {
+                writeln!(
+                    f,
+                    "Stream 0x{:08x} {:?} ({}) @ 0x{:08x}",
+                    stream.stream_type as u32,
+                    stream.stream_type,
+                    stream.vendor,
+                    stream.location.rva,
+                )?;
+            }
+        }
+        if !self.unknown_streams.is_empty() {
+            write!(
+                f,
+                "
+Unknown streams encountered:
+"
+            )?;
+            for stream in &self.unknown_streams {
+                writeln!(
+                    f,
+                    "Stream 0x{:08x} ({}) @ 0x{:08x}",
+                    stream.stream_type, stream.vendor, stream.location.rva,
+                )?;
+            }
         }
         Ok(())
     }

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -231,6 +231,11 @@ where
 
         threads.push(stack);
     }
+
+    // Collect up info on unimplemented/unknown modules
+    let unknown_streams = dump.unknown_streams().collect();
+    let unimplemented_streams = dump.unimplemented_streams().collect();
+
     // if exploitability enabled, run exploitability analysis
     Ok(ProcessState {
         process_id,
@@ -245,5 +250,7 @@ where
         threads,
         modules,
         unloaded_modules,
+        unknown_streams,
+        unimplemented_streams,
     })
 }


### PR DESCRIPTION
I've wanted to this to quickly identify what stuff we're getting in our dumps but doing nothing with. The unimplemented_streams function also serves as a good TODO list :)

Also I currently only report these in the --human format, because I don't want to extend the json format without more serious consideration.