### PR TITLE
Forward Callee-Saved Regs + Add A Million CFI Tests

### DIFF
--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -387,6 +387,8 @@ pub trait FrameWalker {
     fn get_callee_register(&self, name: &str) -> Option<u64>;
     /// Set the value of a register for the caller's frame.
     fn set_caller_register(&mut self, name: &str, val: u64) -> Option<()>;
+    /// Explicitly mark one of the caller's registers as invalid.
+    fn clear_caller_register(&mut self, name: &str);
     /// Set whatever registers in the caller should be set based on the cfa (e.g. rsp).
     fn set_cfa(&mut self, val: u64) -> Option<()>;
     /// Set whatever registers in the caller should be set based on the return address (e.g. rip).

--- a/breakpad-symbols/src/sym_file/walker.rs
+++ b/breakpad-symbols/src/sym_file/walker.rs
@@ -352,8 +352,12 @@ pub fn walk_with_stack_cfi(
             // but make sure to clear it in case it would have been implicitly
             // forwarded from the callee.
             match eval_cfi_expr(expr, walker, Some(cfa)) {
-                Some(val) => { walker.set_caller_register(reg, val); }
-                None => { walker.clear_caller_register(reg); }
+                Some(val) => {
+                    walker.set_caller_register(reg, val);
+                }
+                None => {
+                    walker.clear_caller_register(reg);
+                }
             }
         } else {
             // All special registers should already have been removed??

--- a/minidump-processor/src/stackwalker/amd64.rs
+++ b/minidump-processor/src/stackwalker/amd64.rs
@@ -24,7 +24,7 @@ const INSTRUCTION_REGISTER: &str = "rip";
 const STACK_POINTER_REGISTER: &str = "rsp";
 const FRAME_POINTER_REGISTER: &str = "rbp";
 // FIXME: rdi and rsi are also preserved on windows (but not in sysv) -- we should handle that?
-const CALLEE_SAVED_REGS: &[&str] = &["rbx", "rbp", "rsp", "r12", "r13", "r14", "r15"];
+const CALLEE_SAVED_REGS: &[&str] = &["rbx", "rbp", "r12", "r13", "r14", "r15"];
 
 fn get_caller_by_frame_pointer<P>(
     ctx: &CONTEXT_AMD64,
@@ -186,12 +186,12 @@ where
 
 fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static str> {
     match valid {
-        MinidumpContextValidity::All => {
-            CALLEE_SAVED_REGS.iter().copied().collect()
-        }
-        MinidumpContextValidity::Some(ref which) => {
-            CALLEE_SAVED_REGS.iter().filter(|&reg| which.contains(reg)).copied().collect()
-        }
+        MinidumpContextValidity::All => CALLEE_SAVED_REGS.iter().copied().collect(),
+        MinidumpContextValidity::Some(ref which) => CALLEE_SAVED_REGS
+            .iter()
+            .filter(|&reg| which.contains(reg))
+            .copied()
+            .collect(),
     }
 }
 

--- a/minidump-processor/src/stackwalker/amd64.rs
+++ b/minidump-processor/src/stackwalker/amd64.rs
@@ -23,6 +23,8 @@ const POINTER_WIDTH: Pointer = 8;
 const INSTRUCTION_REGISTER: &str = "rip";
 const STACK_POINTER_REGISTER: &str = "rsp";
 const FRAME_POINTER_REGISTER: &str = "rbp";
+// FIXME: rdi and rsi are also preserved on windows (but not in sysv) -- we should handle that?
+const CALLEE_SAVED_REGS: &[&str] = &["rbx", "rbp", "rsp", "r12", "r13", "r14", "r15"];
 
 fn get_caller_by_frame_pointer<P>(
     ctx: &CONTEXT_AMD64,
@@ -151,8 +153,11 @@ where
         callee_ctx: ctx,
         callee_validity: valid,
 
-        caller_ctx: CONTEXT_AMD64::default(),
-        caller_validity: HashSet::new(),
+        // Default to forwarding all callee-saved regs verbatim.
+        // The CFI evaluator may clear or overwrite these values.
+        // The stack pointer and instruction pointer are not included.
+        caller_ctx: ctx.clone(),
+        caller_validity: callee_forwarded_regs(valid),
 
         stack_memory,
     };
@@ -177,6 +182,17 @@ where
     let mut frame = StackFrame::from_context(context, FrameTrust::CallFrameInfo);
     adjust_instruction(&mut frame, caller_ip);
     Some(frame)
+}
+
+fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static str> {
+    match valid {
+        MinidumpContextValidity::All => {
+            CALLEE_SAVED_REGS.iter().copied().collect()
+        }
+        MinidumpContextValidity::Some(ref which) => {
+            CALLEE_SAVED_REGS.iter().filter(|&reg| which.contains(reg)).copied().collect()
+        }
+    }
 }
 
 fn get_caller_by_scan<P>(

--- a/minidump-processor/src/stackwalker/amd64_unittest.rs
+++ b/minidump-processor/src/stackwalker/amd64_unittest.rs
@@ -52,11 +52,9 @@ impl TestFixture {
         )
     }
 
-    /*
-        pub fn add_symbols(&mut self, name: String, symbols: String) {
-            self.symbols.insert(name, symbols);
-        }
-    */
+    pub fn add_symbols(&mut self, name: String, symbols: String) {
+        self.symbols.insert(name, symbols);
+    }
 }
 
 #[test]
@@ -96,7 +94,7 @@ fn test_caller_pushed_rbp() {
 
     stack = stack
         // frame 0
-        .append_repeated(16, 0) // space
+        .append_repeated(0, 16) // space
         .D64(0x00007400b0000000) // junk that's not
         .D64(0x00007500b0000000) // a return address
         .D64(0x00007400c0001000) // a couple of plausible addresses
@@ -106,7 +104,7 @@ fn test_caller_pushed_rbp() {
         .D64(return_address) // actual return address
         // frame 1
         .mark(&frame1_sp)
-        .append_repeated(32, 0) // body of frame1
+        .append_repeated(0, 32) // body of frame1
         .mark(&frame1_rbp) // end of stack
         .D64(0);
 
@@ -170,13 +168,13 @@ fn test_scan_without_symbols() {
     let frame1_rbp = Label::new();
     stack = stack
         // frame 0
-        .append_repeated(16, 0) // space
+        .append_repeated(0, 16) // space
         .D64(0x00007400b0000000) // junk that's not
         .D64(0x00007500d0000000) // a return address
         .D64(return_address1) // actual return address
         // frame 1
         .mark(&frame1_sp)
-        .append_repeated(16, 0) // space
+        .append_repeated(0, 16) // space
         .D64(0x00007400b0000000) // more junk
         .D64(0x00007500d0000000)
         .mark(&frame1_rbp)
@@ -186,7 +184,7 @@ fn test_scan_without_symbols() {
         .D64(return_address2) // actual return address
         // frame 2
         .mark(&frame2_sp)
-        .append_repeated(32, 0); // end of stack
+        .append_repeated(0, 32); // end of stack
 
     f.raw.rip = 0x00007400c0000200;
     f.raw.rbp = frame1_rbp.value().unwrap();
@@ -241,4 +239,245 @@ fn test_scan_without_symbols() {
             unreachable!();
         }
     }
+}
+
+const CALLEE_SAVE_REGS: &[&str] = &["rip", "rbx", "rbp", "rsp", "r12", "r13", "r14", "r15"];
+
+fn init_cfi_state() -> (TestFixture, Section, CONTEXT_AMD64, MinidumpContextValidity) {
+    let mut f = TestFixture::new();
+    let symbols = [
+        // The youngest frame's function.
+        "FUNC 4000 1000 10 enchiridion\n",
+        // Initially, just a return address.
+        "STACK CFI INIT 4000 100 .cfa: $rsp 8 + .ra: .cfa 8 - ^\n",
+        // Push %rbx.
+        "STACK CFI 4001 .cfa: $rsp 16 + $rbx: .cfa 16 - ^\n",
+        // Save %r12 in %rbx.  Weird, but permitted.
+        "STACK CFI 4002 $r12: $rbx\n",
+        // Allocate frame space, and save %r13.
+        "STACK CFI 4003 .cfa: $rsp 40 + $r13: .cfa 32 - ^\n",
+        // Put the return address in %r13.
+        "STACK CFI 4005 .ra: $r13\n",
+        // Save %rbp, and use it as a frame pointer.
+        "STACK CFI 4006 .cfa: $rbp 16 + $rbp: .cfa 24 - ^\n",
+        // The calling function.
+        "FUNC 5000 1000 10 epictetus\n",
+        // Mark it as end of stack.
+        "STACK CFI INIT 5000 1000 .cfa: $rsp .ra 0\n",
+    ];
+    f.add_symbols(String::from("module1"), symbols.concat());
+
+    f.raw.set_register("rsp", 0x8000000080000000);
+    f.raw.set_register("rip", 0x00007400c0005510);
+    f.raw.set_register("rbp", 0x68995b1de4700266);
+    f.raw.set_register("rbx", 0x5a5beeb38de23be8);
+    f.raw.set_register("r12", 0xed1b02e8cc0fc79c);
+    f.raw.set_register("r13", 0x1d20ad8acacbe930);
+    f.raw.set_register("r14", 0xe94cffc2f7adaa28);
+    f.raw.set_register("r15", 0xb638d17d8da413b5);
+
+    let raw_valid = MinidumpContextValidity::All;
+
+    let expected = f.raw.clone();
+    let expected_regs = CALLEE_SAVE_REGS;
+    let expected_valid = MinidumpContextValidity::Some(expected_regs.iter().copied().collect());
+
+    let stack = Section::new();
+    stack
+        .start()
+        .set_const(f.raw.get_register("rsp", &raw_valid).unwrap());
+
+    (f, stack, expected, expected_valid)
+}
+
+fn check_cfi(
+    f: TestFixture,
+    stack: Section,
+    expected: CONTEXT_AMD64,
+    expected_valid: MinidumpContextValidity,
+) {
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 2);
+
+    {
+        // Frame 0
+        let frame = &s.frames[0];
+        assert_eq!(frame.trust, FrameTrust::Context);
+        assert_eq!(frame.context.valid, MinidumpContextValidity::All);
+    }
+
+    {
+        // Frame 1
+        if let MinidumpContextValidity::Some(ref expected_regs) = expected_valid {
+            let frame = &s.frames[1];
+            let valid = &frame.context.valid;
+            assert_eq!(frame.trust, FrameTrust::CallFrameInfo);
+            if let MinidumpContextValidity::Some(ref which) = valid {
+                assert_eq!(which.len(), expected_regs.len());
+            } else {
+                unreachable!();
+            }
+
+            if let MinidumpRawContext::Amd64(ctx) = &frame.context.raw {
+                for reg in expected_regs {
+                    assert_eq!(
+                        ctx.get_register(reg, valid),
+                        expected.get_register(reg, &expected_valid),
+                        "{} registers didn't match!",
+                        reg
+                    );
+                }
+                return;
+            }
+        }
+    }
+    unreachable!();
+}
+
+#[test]
+fn test_cfi_at_4000() {
+    let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
+
+    let frame1_rsp = Label::new();
+    stack = stack
+        .D64(0x00007400c0005510)
+        .mark(&frame1_rsp)
+        .append_repeated(0, 1000);
+
+    expected.set_register("rsp", frame1_rsp.value().unwrap());
+    f.raw.set_register("rip", 0x00007400c0004000);
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4001() {
+    let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
+
+    let frame1_rsp = Label::new();
+    stack = stack
+        .D64(0x5a5beeb38de23be8) // saved %rbx
+        .D64(0x00007400c0005510) // return address
+        .mark(&frame1_rsp)
+        .append_repeated(0, 1000);
+
+    expected.set_register("rsp", frame1_rsp.value().unwrap());
+    f.raw.set_register("rip", 0x00007400c0004001);
+    f.raw.set_register("rbx", 0xbe0487d2f9eafe29);
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4002() {
+    let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
+
+    let frame1_rsp = Label::new();
+    stack = stack
+        .D64(0x5a5beeb38de23be8) // saved %rbx
+        .D64(0x00007400c0005510) // return address
+        .mark(&frame1_rsp)
+        .append_repeated(0, 1000);
+
+    expected.set_register("rsp", frame1_rsp.value().unwrap());
+    f.raw.set_register("rip", 0x00007400c0004002);
+    f.raw.set_register("rbx", 0xed1b02e8cc0fc79c); // saved %r12
+    f.raw.set_register("r12", 0xb0118de918a4bcea); // callee's (distinct) %r12 value
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4003() {
+    let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
+
+    let frame1_rsp = Label::new();
+    stack = stack
+        .D64(0x0e023828dffd4d81) // garbage
+        .D64(0x1d20ad8acacbe930) // saved %r13
+        .D64(0x319e68b49e3ace0f) // garbage
+        .D64(0x5a5beeb38de23be8) // saved %rbx
+        .D64(0x00007400c0005510) // return address
+        .mark(&frame1_rsp)
+        .append_repeated(0, 1000);
+
+    expected.set_register("rsp", frame1_rsp.value().unwrap());
+    f.raw.set_register("rip", 0x00007400c0004003);
+    f.raw.set_register("rbx", 0xed1b02e8cc0fc79c); // saved %r12
+    f.raw.set_register("r12", 0x89d04fa804c87a43); // callee's (distinct) %r12
+    f.raw.set_register("r13", 0x5118e02cbdb24b03); // callee's (distinct) %r13
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4004() {
+    let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
+
+    let frame1_rsp = Label::new();
+    stack = stack
+        .D64(0x0e023828dffd4d81) // garbage
+        .D64(0x1d20ad8acacbe930) // saved %r13
+        .D64(0x319e68b49e3ace0f) // garbage
+        .D64(0x5a5beeb38de23be8) // saved %rbx
+        .D64(0x00007400c0005510) // return address
+        .mark(&frame1_rsp)
+        .append_repeated(0, 1000);
+
+    expected.set_register("rsp", frame1_rsp.value().unwrap());
+    f.raw.set_register("rip", 0x00007400c0004004);
+    f.raw.set_register("rbx", 0xed1b02e8cc0fc79c); // saved %r12
+    f.raw.set_register("r12", 0x46b1b8868891b34a); // callee's (distinct) %r12
+    f.raw.set_register("r13", 0x5118e02cbdb24b03); // callee's (distinct) %r13
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4005() {
+    let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
+
+    let frame1_rsp = Label::new();
+    stack = stack
+        .D64(0x4b516dd035745953) // garbage
+        .D64(0x1d20ad8acacbe930) // saved %r13
+        .D64(0xa6d445e16ae3d872) // garbage
+        .D64(0x5a5beeb38de23be8) // saved %rbx
+        .D64(0xaa95fa054aedfbae) // garbage
+        .mark(&frame1_rsp)
+        .append_repeated(0, 1000);
+
+    expected.set_register("rsp", frame1_rsp.value().unwrap());
+    f.raw.set_register("rip", 0x00007400c0004005);
+    f.raw.set_register("rbx", 0xed1b02e8cc0fc79c); // saved %r12
+    f.raw.set_register("r12", 0x46b1b8868891b34a); // callee's %r12
+    f.raw.set_register("r13", 0x00007400c0005510); // return address
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4006() {
+    let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
+
+    let frame0_rbp = Label::new();
+    let frame1_rsp = Label::new();
+    stack = stack
+        .D64(0x043c6dfceb91aa34) // garbage
+        .D64(0x1d20ad8acacbe930) // saved %r13
+        .D64(0x68995b1de4700266) // saved %rbp
+        .mark(&frame0_rbp) // frame pointer points here
+        .D64(0x5a5beeb38de23be8) // saved %rbx
+        .D64(0xf015ee516ad89eab) // garbage
+        .mark(&frame1_rsp)
+        .append_repeated(0, 1000);
+
+    expected.set_register("rsp", frame1_rsp.value().unwrap());
+    f.raw.set_register("rip", 0x00007400c0004006);
+    f.raw.set_register("rbp", frame0_rbp.value().unwrap());
+    f.raw.set_register("rbx", 0xed1b02e8cc0fc79c); // saved %r12
+    f.raw.set_register("r12", 0x26e007b341acfebd); // callee's %r12
+    f.raw.set_register("r13", 0x00007400c0005510); // return address
+
+    check_cfi(f, stack, expected, expected_valid);
 }

--- a/minidump-processor/src/stackwalker/arm.rs
+++ b/minidump-processor/src/stackwalker/arm.rs
@@ -172,12 +172,12 @@ where
 
 fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static str> {
     match valid {
-        MinidumpContextValidity::All => {
-            CALLEE_SAVED_REGS.iter().copied().collect()
-        }
-        MinidumpContextValidity::Some(ref which) => {
-            CALLEE_SAVED_REGS.iter().filter(|&reg| which.contains(reg)).copied().collect()
-        }
+        MinidumpContextValidity::All => CALLEE_SAVED_REGS.iter().copied().collect(),
+        MinidumpContextValidity::Some(ref which) => CALLEE_SAVED_REGS
+            .iter()
+            .filter(|&reg| which.contains(reg))
+            .copied()
+            .collect(),
     }
 }
 
@@ -266,7 +266,7 @@ fn stack_seems_valid(
     stack_memory: &MinidumpMemory,
 ) -> bool {
     // The stack shouldn't *grow* when we unwind
-    if caller_sp <= callee_sp {
+    if caller_sp < callee_sp {
         return false;
     }
 
@@ -316,7 +316,7 @@ impl Unwind for ArmContext {
                 // If the new stack pointer is at a lower address than the old,
                 // then that's clearly incorrect. Treat this as end-of-stack to
                 // enforce progress and avoid infinite loops.
-                if frame.context.get_stack_pointer() <= self.get_register_always("sp") as u64 {
+                if frame.context.get_stack_pointer() < self.get_register_always("sp") as u64 {
                     return None;
                 }
                 Some(frame)

--- a/minidump-processor/src/stackwalker/arm64.rs
+++ b/minidump-processor/src/stackwalker/arm64.rs
@@ -24,7 +24,9 @@ const FRAME_POINTER: &str = Registers::FramePointer.name();
 const STACK_POINTER: &str = Registers::StackPointer.name();
 const LINK_REGISTER: &str = Registers::LinkRegister.name();
 const PROGRAM_COUNTER: &str = Registers::ProgramCounter.name();
-const CALLEE_SAVED_REGS: &[&str] = &["x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28", "x29"];
+const CALLEE_SAVED_REGS: &[&str] = &[
+    "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28", "x29",
+];
 
 fn get_caller_by_frame_pointer<P>(
     ctx: &ArmContext,
@@ -231,12 +233,12 @@ where
 
 fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static str> {
     match valid {
-        MinidumpContextValidity::All => {
-            CALLEE_SAVED_REGS.iter().copied().collect()
-        }
-        MinidumpContextValidity::Some(ref which) => {
-            CALLEE_SAVED_REGS.iter().filter(|&reg| which.contains(reg)).copied().collect()
-        }
+        MinidumpContextValidity::All => CALLEE_SAVED_REGS.iter().copied().collect(),
+        MinidumpContextValidity::Some(ref which) => CALLEE_SAVED_REGS
+            .iter()
+            .filter(|&reg| which.contains(reg))
+            .copied()
+            .collect(),
     }
 }
 

--- a/minidump-processor/src/stackwalker/arm64.rs
+++ b/minidump-processor/src/stackwalker/arm64.rs
@@ -24,6 +24,7 @@ const FRAME_POINTER: &str = Registers::FramePointer.name();
 const STACK_POINTER: &str = Registers::StackPointer.name();
 const LINK_REGISTER: &str = Registers::LinkRegister.name();
 const PROGRAM_COUNTER: &str = Registers::ProgramCounter.name();
+const CALLEE_SAVED_REGS: &[&str] = &["x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28", "x29"];
 
 fn get_caller_by_frame_pointer<P>(
     ctx: &ArmContext,
@@ -196,8 +197,11 @@ where
         callee_ctx: ctx,
         callee_validity: valid,
 
-        caller_ctx: ArmContext::default(),
-        caller_validity: HashSet::new(),
+        // Default to forwarding all callee-saved regs verbatim.
+        // The CFI evaluator may clear or overwrite these values.
+        // The stack pointer and instruction pointer are not included.
+        caller_ctx: ctx.clone(),
+        caller_validity: callee_forwarded_regs(valid),
 
         stack_memory,
     };
@@ -223,6 +227,17 @@ where
     let mut frame = StackFrame::from_context(context, FrameTrust::CallFrameInfo);
     adjust_instruction(&mut frame, caller_pc);
     Some(frame)
+}
+
+fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static str> {
+    match valid {
+        MinidumpContextValidity::All => {
+            CALLEE_SAVED_REGS.iter().copied().collect()
+        }
+        MinidumpContextValidity::Some(ref which) => {
+            CALLEE_SAVED_REGS.iter().filter(|&reg| which.contains(reg)).copied().collect()
+        }
+    }
 }
 
 fn get_caller_by_scan<P>(

--- a/minidump-processor/src/stackwalker/arm64_old.rs
+++ b/minidump-processor/src/stackwalker/arm64_old.rs
@@ -203,7 +203,7 @@ where
         // Default to forwarding all callee-saved regs verbatim.
         // The CFI evaluator may clear or overwrite these values.
         // The stack pointer and instruction pointer are not included.
-        caller_ctx: ctx.clone(),
+        caller_ctx: *ctx,
         caller_validity: callee_forwarded_regs(valid),
 
         stack_memory,

--- a/minidump-processor/src/stackwalker/arm64_old.rs
+++ b/minidump-processor/src/stackwalker/arm64_old.rs
@@ -24,6 +24,9 @@ const FRAME_POINTER: &str = Registers::FramePointer.name();
 const STACK_POINTER: &str = Registers::StackPointer.name();
 const LINK_REGISTER: &str = Registers::LinkRegister.name();
 const PROGRAM_COUNTER: &str = Registers::ProgramCounter.name();
+const CALLEE_SAVED_REGS: &[&str] = &[
+    "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28", "x29",
+];
 
 fn get_caller_by_frame_pointer<P>(
     ctx: &ArmContext,
@@ -197,8 +200,11 @@ where
         callee_ctx: ctx,
         callee_validity: valid,
 
-        caller_ctx: ArmContext::default(),
-        caller_validity: HashSet::new(),
+        // Default to forwarding all callee-saved regs verbatim.
+        // The CFI evaluator may clear or overwrite these values.
+        // The stack pointer and instruction pointer are not included.
+        caller_ctx: ctx.clone(),
+        caller_validity: callee_forwarded_regs(valid),
 
         stack_memory,
     };
@@ -224,6 +230,17 @@ where
     let mut frame = StackFrame::from_context(context, FrameTrust::CallFrameInfo);
     adjust_instruction(&mut frame, caller_pc);
     Some(frame)
+}
+
+fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static str> {
+    match valid {
+        MinidumpContextValidity::All => CALLEE_SAVED_REGS.iter().copied().collect(),
+        MinidumpContextValidity::Some(ref which) => CALLEE_SAVED_REGS
+            .iter()
+            .filter(|&reg| which.contains(reg))
+            .copied()
+            .collect(),
+    }
 }
 
 fn get_caller_by_scan<P>(

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -389,8 +389,7 @@ fn test_frame_pointer() {
         }
     }
 }
-
-// const CALLEE_SAVE_REGS: [&str; 13] = ["pc", "sp", "fp", "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28"];
+const CALLEE_SAVE_REGS: &[&str] = &["pc", "sp", "fp", "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28"];
 
 #[test]
 fn test_cfi_at_4000() {
@@ -399,9 +398,9 @@ fn test_cfi_at_4000() {
     let raw_valid = MinidumpContextValidity::All;
 
     let expected = f.raw.clone();
-    let expected_regs = ["pc", "sp"];
+    let expected_regs = CALLEE_SAVE_REGS;
     let expected_valid =
-        MinidumpContextValidity::Some(std::array::IntoIter::new(expected_regs).collect());
+        MinidumpContextValidity::Some(expected_regs.iter().copied().collect());
 
     let mut stack = Section::new();
     stack = stack.append_repeated(0, 120);
@@ -434,7 +433,7 @@ fn test_cfi_at_4000() {
         }
 
         if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
-            for reg in &expected_regs {
+            for reg in expected_regs {
                 assert_eq!(
                     ctx.get_register(reg, valid),
                     expected.get_register(reg, &expected_valid),

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -59,61 +59,6 @@ impl TestFixture {
     pub fn add_symbols(&mut self, name: String, symbols: String) {
         self.symbols.insert(name, symbols);
     }
-
-    pub fn init_cfi_state(&mut self) {
-        let symbols = [
-            // The youngest frame's function.
-            "FUNC 4000 1000 10 enchiridion\n",
-            // Initially, nothing has been pushed on the stack,
-            // and the return address is still in the link
-            // register (x30).
-            "STACK CFI INIT 4000 100 .cfa: sp 0 + .ra: x30\n",
-            // Push x19, x20, the frame pointer and the link register.
-            "STACK CFI 4001 .cfa: sp 32 + .ra: .cfa -8 + ^",
-            " x19: .cfa -32 + ^ x20: .cfa -24 + ^ ",
-            " x29: .cfa -16 + ^\n",
-            // Save x19..x22 in x0..x3: verify that we populate
-            // the youngest frame with all the values we have.
-            "STACK CFI 4002 x19: x0 x20: x1 x21: x2 x22: x3\n",
-            // Restore x19..x22. Save the non-callee-saves register x1.
-            "STACK CFI 4003 .cfa: sp 40 + x1: .cfa 40 - ^",
-            " x19: x19 x20: x20 x21: x21 x22: x22\n",
-            // Move the .cfa back eight bytes, to point at the return
-            // address, and restore the sp explicitly.
-            "STACK CFI 4005 .cfa: sp 32 + x1: .cfa 32 - ^",
-            " x29: .cfa 8 - ^ .ra: .cfa ^ sp: .cfa 8 +\n",
-            // Recover the PC explicitly from a new stack slot;
-            // provide garbage for the .ra.
-            "STACK CFI 4006 .cfa: sp 40 + pc: .cfa 40 - ^\n",
-            // The calling function.
-            "FUNC 5000 1000 10 epictetus\n",
-            // Mark it as end of stack.
-            "STACK CFI INIT 5000 1000 .cfa: 0 .ra: 0\n",
-            // A function whose CFI makes the stack pointer
-            // go backwards.
-            "FUNC 6000 1000 20 palinal\n",
-            "STACK CFI INIT 6000 1000 .cfa: sp 8 - .ra: x30\n",
-            // A function with CFI expressions that can't be
-            // evaluated.
-            "FUNC 7000 1000 20 rhetorical\n",
-            "STACK CFI INIT 7000 1000 .cfa: moot .ra: ambiguous\n",
-        ];
-        self.add_symbols(String::from("module1"), symbols.concat());
-
-        self.raw.set_register("pc", 0x0000000040005510);
-        self.raw.set_register("sp", 0x0000000080000000);
-        self.raw.set_register("fp", 0xe11081128112e110);
-        self.raw.set_register("x19", 0x5e68b5d5b5d55e68);
-        self.raw.set_register("x20", 0x34f3ebd1ebd134f3);
-        self.raw.set_register("x21", 0x74bca31ea31e74bc);
-        self.raw.set_register("x22", 0x16b32dcb2dcb16b3);
-        self.raw.set_register("x23", 0x21372ada2ada2137);
-        self.raw.set_register("x24", 0x557dbbbbbbbb557d);
-        self.raw.set_register("x25", 0x8ca748bf48bf8ca7);
-        self.raw.set_register("x26", 0x21f0ab46ab4621f0);
-        self.raw.set_register("x27", 0x146732b732b71467);
-        self.raw.set_register("x28", 0xa673645fa673645f);
-    }
 }
 
 #[test]
@@ -389,28 +334,85 @@ fn test_frame_pointer() {
         }
     }
 }
-const CALLEE_SAVE_REGS: &[&str] = &["pc", "sp", "fp", "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28"];
+const CALLEE_SAVE_REGS: &[&str] = &[
+    "pc", "sp", "fp", "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28",
+];
 
-#[test]
-fn test_cfi_at_4000() {
+fn init_cfi_state() -> (TestFixture, Section, Context, MinidumpContextValidity) {
     let mut f = TestFixture::new();
-    f.init_cfi_state();
+    let symbols = [
+        // The youngest frame's function.
+        "FUNC 4000 1000 10 enchiridion\n",
+        // Initially, nothing has been pushed on the stack,
+        // and the return address is still in the link
+        // register (x30).
+        "STACK CFI INIT 4000 100 .cfa: sp 0 + .ra: x30\n",
+        // Push x19, x20, the frame pointer and the link register.
+        "STACK CFI 4001 .cfa: sp 32 + .ra: .cfa -8 + ^",
+        " x19: .cfa -32 + ^ x20: .cfa -24 + ^ ",
+        " x29: .cfa -16 + ^\n",
+        // Save x19..x22 in x0..x3: verify that we populate
+        // the youngest frame with all the values we have.
+        "STACK CFI 4002 x19: x0 x20: x1 x21: x2 x22: x3\n",
+        // Restore x19..x22. Save the non-callee-saves register x1.
+        "STACK CFI 4003 .cfa: sp 40 + x1: .cfa 40 - ^",
+        " x19: x19 x20: x20 x21: x21 x22: x22\n",
+        // Move the .cfa back eight bytes, to point at the return
+        // address, and restore the sp explicitly.
+        "STACK CFI 4005 .cfa: sp 32 + x1: .cfa 32 - ^",
+        " x29: .cfa 8 - ^ .ra: .cfa ^ sp: .cfa 8 +\n",
+        // Recover the PC explicitly from a new stack slot;
+        // provide garbage for the .ra.
+        "STACK CFI 4006 .cfa: sp 40 + pc: .cfa 40 - ^\n",
+        // The calling function.
+        "FUNC 5000 1000 10 epictetus\n",
+        // Mark it as end of stack.
+        "STACK CFI INIT 5000 1000 .cfa: 0 .ra: 0\n",
+        // A function whose CFI makes the stack pointer
+        // go backwards.
+        "FUNC 6000 1000 20 palinal\n",
+        "STACK CFI INIT 6000 1000 .cfa: sp 8 - .ra: x30\n",
+        // A function with CFI expressions that can't be
+        // evaluated.
+        "FUNC 7000 1000 20 rhetorical\n",
+        "STACK CFI INIT 7000 1000 .cfa: moot .ra: ambiguous\n",
+    ];
+    f.add_symbols(String::from("module1"), symbols.concat());
+
+    f.raw.set_register("pc", 0x0000000040005510);
+    f.raw.set_register("sp", 0x0000000080000000);
+    f.raw.set_register("fp", 0xe11081128112e110);
+    f.raw.set_register("x19", 0x5e68b5d5b5d55e68);
+    f.raw.set_register("x20", 0x34f3ebd1ebd134f3);
+    f.raw.set_register("x21", 0x74bca31ea31e74bc);
+    f.raw.set_register("x22", 0x16b32dcb2dcb16b3);
+    f.raw.set_register("x23", 0x21372ada2ada2137);
+    f.raw.set_register("x24", 0x557dbbbbbbbb557d);
+    f.raw.set_register("x25", 0x8ca748bf48bf8ca7);
+    f.raw.set_register("x26", 0x21f0ab46ab4621f0);
+    f.raw.set_register("x27", 0x146732b732b71467);
+    f.raw.set_register("x28", 0xa673645fa673645f);
+
     let raw_valid = MinidumpContextValidity::All;
 
     let expected = f.raw.clone();
     let expected_regs = CALLEE_SAVE_REGS;
-    let expected_valid =
-        MinidumpContextValidity::Some(expected_regs.iter().copied().collect());
+    let expected_valid = MinidumpContextValidity::Some(expected_regs.iter().copied().collect());
 
-    let mut stack = Section::new();
-    stack = stack.append_repeated(0, 120);
+    let stack = Section::new();
     stack
         .start()
         .set_const(f.raw.get_register("sp", &raw_valid).unwrap());
 
-    f.raw.set_register("pc", 0x0000000040004000);
-    f.raw.set_register("lr", 0x0000000040005510);
+    (f, stack, expected, expected_valid)
+}
 
+fn check_cfi(
+    f: TestFixture,
+    stack: Section,
+    expected: Context,
+    expected_valid: MinidumpContextValidity,
+) {
     let s = f.walk_stack(stack);
     assert_eq!(s.frames.len(), 2);
 
@@ -423,26 +425,245 @@ fn test_cfi_at_4000() {
 
     {
         // Frame 1
-        let frame = &s.frames[1];
-        let valid = &frame.context.valid;
-        assert_eq!(frame.trust, FrameTrust::CallFrameInfo);
-        if let MinidumpContextValidity::Some(ref which) = valid {
-            assert_eq!(which.len(), expected_regs.len());
-        } else {
-            unreachable!();
-        }
-
-        if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
-            for reg in expected_regs {
-                assert_eq!(
-                    ctx.get_register(reg, valid),
-                    expected.get_register(reg, &expected_valid),
-                    "{} registers didn't match!",
-                    reg
-                );
+        if let MinidumpContextValidity::Some(ref expected_regs) = expected_valid {
+            let frame = &s.frames[1];
+            let valid = &frame.context.valid;
+            assert_eq!(frame.trust, FrameTrust::CallFrameInfo);
+            if let MinidumpContextValidity::Some(ref which) = valid {
+                assert_eq!(which.len(), expected_regs.len());
+            } else {
+                unreachable!();
             }
-        } else {
-            unreachable!();
+
+            if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
+                for reg in expected_regs {
+                    assert_eq!(
+                        ctx.get_register(reg, valid),
+                        expected.get_register(reg, &expected_valid),
+                        "{} registers didn't match!",
+                        reg
+                    );
+                }
+                return;
+            }
         }
     }
+    unreachable!();
+}
+
+#[test]
+fn test_cfi_at_4000() {
+    let (mut f, mut stack, expected, expected_valid) = init_cfi_state();
+
+    stack = stack.append_repeated(0, 120);
+
+    f.raw.set_register("pc", 0x0000000040004000);
+    f.raw.set_register("lr", 0x0000000040005510);
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4001() {
+    let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
+
+    let frame1_sp = Label::new();
+    stack = stack
+        .D64(0x5e68b5d5b5d55e68) // saved x19
+        .D64(0x34f3ebd1ebd134f3) // saved x20
+        .D64(0xe11081128112e110) // saved fp
+        .D64(0x0000000040005510) // return address
+        .mark(&frame1_sp)
+        .append_repeated(0, 120);
+
+    expected.set_register("sp", frame1_sp.value().unwrap());
+    f.raw.set_register("pc", 0x0000000040004001);
+    f.raw.set_register("x19", 0xadc9f635a635adc9);
+    f.raw.set_register("x20", 0x623135ac35ac6231);
+    f.raw.set_register("fp", 0x5fc4be14be145fc4);
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4002() {
+    let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
+
+    let frame1_sp = Label::new();
+    stack = stack
+        .D64(0xff3dfb81fb81ff3d) // no longer saved x19
+        .D64(0x34f3ebd1ebd134f3) // no longer saved x20
+        .D64(0xe11081128112e110) // saved fp
+        .D64(0x0000000040005510) // return address
+        .mark(&frame1_sp)
+        .append_repeated(0, 120);
+
+    expected.set_register("sp", frame1_sp.value().unwrap());
+    f.raw.set_register("pc", 0x0000000040004002);
+    f.raw.iregs[0] = 0x5e68b5d5b5d55e68; // saved x19
+    f.raw.iregs[1] = 0x34f3ebd1ebd134f3; // saved x20
+    f.raw.iregs[2] = 0x74bca31ea31e74bc; // saved x21
+    f.raw.iregs[3] = 0x16b32dcb2dcb16b3; // saved x22
+    f.raw.iregs[19] = 0xadc9f635a635adc9; // distinct callee x19
+    f.raw.iregs[20] = 0x623135ac35ac6231; // distinct callee x20
+    f.raw.iregs[21] = 0xac4543564356ac45; // distinct callee x21
+    f.raw.iregs[22] = 0x2561562f562f2561; // distinct callee x22
+    f.raw.set_register("fp", 0x5fc4be14be145fc4);
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4003() {
+    let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
+
+    let frame1_sp = Label::new();
+    stack = stack
+        .D64(0xdd5a48c848c8dd5a) // saved x1 (even though it's not callee-saves)
+        .D64(0xff3dfb81fb81ff3d) // no longer saved x19
+        .D64(0x34f3ebd1ebd134f3) // no longer saved x20
+        .D64(0xe11081128112e110) // saved fp
+        .D64(0x0000000040005510) // return address
+        .mark(&frame1_sp)
+        .append_repeated(0, 120);
+
+    expected.set_register("sp", frame1_sp.value().unwrap());
+    expected.iregs[1] = 0xdd5a48c848c8dd5a;
+    if let MinidumpContextValidity::Some(ref mut which) = expected_valid {
+        which.insert("x1");
+    } else {
+        unreachable!();
+    }
+
+    f.raw.set_register("pc", 0x0000000040004003);
+    f.raw.iregs[1] = 0xfb756319fb756319;
+    f.raw.set_register("fp", 0x5fc4be14be145fc4);
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4004() {
+    // Should just be the same as 4003
+
+    let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
+
+    let frame1_sp = Label::new();
+    stack = stack
+        .D64(0xdd5a48c848c8dd5a) // saved x1 (even though it's not callee-saves)
+        .D64(0xff3dfb81fb81ff3d) // no longer saved x19
+        .D64(0x34f3ebd1ebd134f3) // no longer saved x20
+        .D64(0xe11081128112e110) // saved fp
+        .D64(0x0000000040005510) // return address
+        .mark(&frame1_sp)
+        .append_repeated(0, 120);
+
+    expected.set_register("sp", frame1_sp.value().unwrap());
+    expected.iregs[1] = 0xdd5a48c848c8dd5a;
+    if let MinidumpContextValidity::Some(ref mut which) = expected_valid {
+        which.insert("x1");
+    } else {
+        unreachable!();
+    }
+
+    f.raw.set_register("pc", 0x0000000040004004);
+    f.raw.iregs[1] = 0xfb756319fb756319;
+    f.raw.set_register("fp", 0x5fc4be14be145fc4);
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4005() {
+    // Here we move the .cfa, but provide an explicit rule to recover the SP,
+    // so again there should be no change in the registers recovered.
+
+    let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
+
+    let frame1_sp = Label::new();
+    stack = stack
+        .D64(0xdd5a48c848c8dd5a) // saved x1 (even though it's not callee-saves)
+        .D64(0xff3dfb81fb81ff3d) // no longer saved x19
+        .D64(0x34f3ebd1ebd134f3) // no longer saved x20
+        .D64(0xe11081128112e110) // saved fp
+        .D64(0x0000000040005510) // return address
+        .mark(&frame1_sp)
+        .append_repeated(0, 120);
+
+    expected.set_register("sp", frame1_sp.value().unwrap());
+    expected.iregs[1] = 0xdd5a48c848c8dd5a;
+    if let MinidumpContextValidity::Some(ref mut which) = expected_valid {
+        which.insert("x1");
+    } else {
+        unreachable!();
+    }
+
+    f.raw.set_register("pc", 0x0000000040004005);
+    f.raw.iregs[1] = 0xfb756319fb756319;
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_at_4006() {
+    // Here we provide an explicit rule for the PC, and have the saved .ra be
+    // bogus.
+
+    let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
+
+    let frame1_sp = Label::new();
+    stack = stack
+        .D64(0x0000000040005510) // saved pc
+        .D64(0xdd5a48c848c8dd5a) // saved x1 (even though it's not callee-saves)
+        .D64(0xff3dfb81fb81ff3d) // no longer saved x19
+        .D64(0x34f3ebd1ebd134f3) // no longer saved x20
+        .D64(0xe11081128112e110) // saved fp
+        .D64(0xf8d157835783f8d1) // .ra rule recovers this, which is garbage
+        .mark(&frame1_sp)
+        .append_repeated(0, 120);
+
+    expected.set_register("sp", frame1_sp.value().unwrap());
+    expected.iregs[1] = 0xdd5a48c848c8dd5a;
+    if let MinidumpContextValidity::Some(ref mut which) = expected_valid {
+        which.insert("x1");
+    } else {
+        unreachable!();
+    }
+
+    f.raw.set_register("pc", 0x0000000040004006);
+    f.raw.iregs[1] = 0xfb756319fb756319;
+
+    check_cfi(f, stack, expected, expected_valid);
+}
+
+#[test]
+fn test_cfi_reject_backwards() {
+    // Check that we reject rules that would cause the stack pointer to
+    // move in the wrong direction.
+
+    let (mut f, mut stack, _expected, _expected_valid) = init_cfi_state();
+
+    stack = stack.append_repeated(0, 120);
+
+    f.raw.set_register("pc", 0x0000000040006000);
+    f.raw.set_register("sp", 0x0000000080000000);
+    f.raw.set_register("lr", 0x0000000040005510);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 1);
+}
+
+#[test]
+fn test_cfi_reject_bad_exprs() {
+    // Check that we reject rules whose expressions' evaluation fails.
+
+    let (mut f, mut stack, _expected, _expected_valid) = init_cfi_state();
+
+    stack = stack.append_repeated(0, 120);
+
+    f.raw.set_register("pc", 0x0000000040007000);
+    f.raw.set_register("sp", 0x0000000080000000);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 1);
 }

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -60,6 +60,9 @@ where
         self.caller_validity.insert(memoized);
         self.caller_ctx.set_register(name, val)
     }
+    fn clear_caller_register(&mut self, name: &str) {
+        self.caller_validity.remove(name);
+    }
     fn set_cfa(&mut self, val: u64) -> Option<()> {
         // TODO: some things have alluded to architectures where this isn't
         // how the CFA should be handled, but I don't know what they are.

--- a/minidump-processor/src/stackwalker/x86.rs
+++ b/minidump-processor/src/stackwalker/x86.rs
@@ -23,6 +23,7 @@ const POINTER_WIDTH: Pointer = 4;
 const INSTRUCTION_REGISTER: &str = "eip";
 const STACK_POINTER_REGISTER: &str = "esp";
 const FRAME_POINTER_REGISTER: &str = "ebp";
+const CALLEE_SAVED_REGS: &[&str] = &["ebp", "ebx", "edi", "esi"];
 
 fn get_caller_by_frame_pointer<P>(
     ctx: &CONTEXT_X86,
@@ -133,8 +134,11 @@ where
         callee_ctx: ctx,
         callee_validity: valid,
 
-        caller_ctx: CONTEXT_X86::default(),
-        caller_validity: HashSet::new(),
+        // Default to forwarding all callee-saved regs verbatim.
+        // The CFI evaluator may clear or overwrite these values.
+        // The stack pointer and instruction pointer are not included.
+        caller_ctx: ctx.clone(),
+        caller_validity: callee_forwarded_regs(valid),
 
         stack_memory,
     };
@@ -159,6 +163,17 @@ where
     let mut frame = StackFrame::from_context(context, FrameTrust::CallFrameInfo);
     adjust_instruction(&mut frame, caller_ip);
     Some(frame)
+}
+
+fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static str> {
+    match valid {
+        MinidumpContextValidity::All => {
+            CALLEE_SAVED_REGS.iter().copied().collect()
+        }
+        MinidumpContextValidity::Some(ref which) => {
+            CALLEE_SAVED_REGS.iter().filter(|&reg| which.contains(reg)).copied().collect()
+        }
+    }
 }
 
 fn get_caller_by_scan<P>(

--- a/minidump-processor/src/stackwalker/x86.rs
+++ b/minidump-processor/src/stackwalker/x86.rs
@@ -167,12 +167,12 @@ where
 
 fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static str> {
     match valid {
-        MinidumpContextValidity::All => {
-            CALLEE_SAVED_REGS.iter().copied().collect()
-        }
-        MinidumpContextValidity::Some(ref which) => {
-            CALLEE_SAVED_REGS.iter().filter(|&reg| which.contains(reg)).copied().collect()
-        }
+        MinidumpContextValidity::All => CALLEE_SAVED_REGS.iter().copied().collect(),
+        MinidumpContextValidity::Some(ref which) => CALLEE_SAVED_REGS
+            .iter()
+            .filter(|&reg| which.contains(reg))
+            .copied()
+            .collect(),
     }
 }
 

--- a/minidump-processor/src/symbols.rs
+++ b/minidump-processor/src/symbols.rs
@@ -124,6 +124,8 @@ mod symbols_shim {
         fn get_callee_register(&self, name: &str) -> Option<u64>;
         /// Set the value of a register for the caller's frame.
         fn set_caller_register(&mut self, name: &str, val: u64) -> Option<()>;
+        /// Explicitly mark one of the caller's registers as invalid.
+        fn clear_caller_register(&mut self, name: &str);
         /// Set whatever registers in the caller should be set based on the cfa (e.g. rsp).
         fn set_cfa(&mut self, val: u64) -> Option<()>;
         /// Set whatever registers in the caller should be set based on the return address (e.g. rip).

--- a/minidump/src/context.rs
+++ b/minidump/src/context.rs
@@ -41,7 +41,7 @@ pub trait CpuContext {
         if let MinidumpContextValidity::Some(ref which) = *valid {
             which.contains(reg)
         } else {
-            true
+            self.memoize_register(reg).is_some()
         }
     }
     /// Get a register value if it is valid.
@@ -210,7 +210,7 @@ impl CpuContext for md::CONTEXT_ARM {
                 _ => which.contains(reg),
             }
         } else {
-            true
+            self.memoize_register(reg).is_some()
         }
     }
 
@@ -292,7 +292,7 @@ impl CpuContext for md::CONTEXT_ARM64_OLD {
                 _ => which.contains(reg),
             }
         } else {
-            true
+            self.memoize_register(reg).is_some()
         }
     }
 
@@ -404,7 +404,7 @@ impl CpuContext for md::CONTEXT_ARM64 {
                 _ => which.contains(reg),
             }
         } else {
-            true
+            self.memoize_register(reg).is_some()
         }
     }
 


### PR DESCRIPTION
Some notable changes:

* Callee-saved registers are now forwarded by default (except stack pointer and instruction pointer)
* FrameWalker now has a `clear_caller_register` method to allow the CFI walker to delete forwarded callee-saved registers (e.g. when the register has a rule but it doesn't eval properly) 
* ARM(32) unwinder now allows stack frames to have the same `sp` value (stacks is not strictly monotonic), matching ARM64 behaviour
* get_register for MinidumpContextValidity::All now properly checks that the requested register is part of the context's register list

This notably omits the STACK WIN tests in `stackwalker_x86_unittest.cc` because I don't have a working implementation of that format and those tests are far less regular than the CFI ones.
