### PR TITLE
Minimal exploitability impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,7 @@ dependencies = [
  "log",
  "memmap 0.7.0",
  "minidump",
+ "num-traits 0.2.14",
  "object 0.24.0",
  "scroll 0.10.2",
  "serde",

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -30,6 +30,7 @@ gimli = "0.24"
 log = "0.4"
 memmap = "0.7.0"
 minidump = { version = "0.9.1", path = "../minidump" }
+num-traits = "0.2"
 object = "0.24"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/minidump-processor/src/exploitability.rs
+++ b/minidump-processor/src/exploitability.rs
@@ -1,0 +1,271 @@
+use crate::ProcessState;
+use log::{trace, warn};
+use minidump::format::{
+    ExceptionCodeLinux, ExceptionCodeWindows, ExceptionCodeWindowsAccessType, NtStatusWindows,
+    WinErrorWindows,
+};
+use minidump::system_info::Os;
+use minidump::{CrashReason, MinidumpMemoryList};
+use num_traits::FromPrimitive;
+
+/// An estimate of how exploitable a crash is.
+pub enum Exploitability {
+    /// The crash is likely to be an exploitabile memory corruption.
+    High,
+    /// The crash might be an exploitable memory corruption.
+    Medium,
+    /// The crash either does not corrupt memory directly, or control over
+    /// the affected data is limited. May be exploitable under different
+    /// conditions, like on another platform.
+    Low,
+    /// The crash doesn't seem directly explotiable, but conditions are
+    /// suspicious and it merits investigation.
+    Interesting,
+    /// The crash doesn't seem exploitable.
+    None,
+}
+
+impl Exploitability {
+    fn from_weight(weight: u32) -> Self {
+        if weight >= HIGH_CUTOFF {
+            Exploitability::High
+        } else if weight >= MEDIUM_CUTOFF {
+            Exploitability::Medium
+        } else if weight >= LOW_CUTOFF {
+            Exploitability::Low
+        } else if weight >= INTERESTING_CUTOFF {
+            Exploitability::Interesting
+        } else {
+            Exploitability::None
+        }
+    }
+
+    pub fn to_str(&self) -> &'static str {
+        match self {
+            Self::High => "high",
+            Self::Medium => "medium",
+            Self::Low => "low",
+            Self::Interesting => "interesting",
+            Self::None => "none",
+        }
+    }
+}
+
+// Range from the stack pointer that we will consider "in the stack"
+const PROBABLE_STACK_OFFSET: u64 = 8192;
+// Range from null that we will consider "null"
+const PROBABLE_NULL_OFFSET: u64 = 4096;
+// How many bytes we're willing to disassemble past the program counter.
+const DISSASSEMBLY_RANGE: usize = 2048;
+
+// How many points are needed to get a particular rating
+const HIGH_CUTOFF: u32 = 100;
+const MEDIUM_CUTOFF: u32 = 80;
+const LOW_CUTOFF: u32 = 50;
+const INTERESTING_CUTOFF: u32 = 25;
+
+// Predefined point increments
+const TINY_BUMP: u32 = 5;
+const SMALL_BUMP: u32 = 20;
+const MEDIUM_BUMP: u32 = 50;
+const LARGE_BUMP: u32 = 70;
+const HUGE_BUMP: u32 = 90;
+
+pub(crate) fn analyze(state: &mut ProcessState, memory: &MinidumpMemoryList) {
+    let exploitability = match state.system_info.os {
+        Os::Windows => windows_exploitability(state, memory),
+        Os::Linux => linux_exploitability(state, memory),
+        _ => None,
+    };
+    state.exploitability = exploitability;
+}
+
+fn windows_exploitability(
+    state: &ProcessState,
+    memory: &MinidumpMemoryList,
+) -> Option<Exploitability> {
+    use ExceptionCodeWindows::*;
+    use NtStatusWindows::*;
+    use WinErrorWindows::*;
+
+    let mut exploitability_weight = 0;
+
+    let crash_reason = state.crash_reason?;
+    let crash_address = state.crash_address?;
+    let crashing_thread_id = state.requesting_thread?;
+    let crashing_thread = state.threads.get(crashing_thread_id)?;
+    let crashing_frame = crashing_thread.frames.first()?;
+    let crashing_ctx = &crashing_frame.context;
+    let exception_code = state.exception_code?;
+
+    let instruction_ptr = crashing_ctx.get_instruction_pointer();
+    let stack_ptr = crashing_ctx.get_stack_pointer();
+
+    // If the instruction pointer is pointing in the stack, that's a nightmare
+    let fuzzy_stack = stack_ptr.saturating_sub(PROBABLE_STACK_OFFSET)
+        ..=stack_ptr.saturating_add(PROBABLE_STACK_OFFSET);
+    if fuzzy_stack.contains(&instruction_ptr) {
+        exploitability_weight += HUGE_BUMP;
+    }
+
+    if let Some(exception) = ExceptionCodeWindows::from_u32(exception_code) {
+        match exception {
+            EXCEPTION_STACK_OVERFLOW => {
+                // Probably just recursion
+                exploitability_weight += TINY_BUMP;
+            }
+            EXCEPTION_FLT_DENORMAL_OPERAND
+            | EXCEPTION_FLT_DIVIDE_BY_ZERO
+            | EXCEPTION_FLT_INEXACT_RESULT
+            | EXCEPTION_FLT_OVERFLOW
+            | EXCEPTION_FLT_UNDERFLOW
+            | EXCEPTION_INT_DIVIDE_BY_ZERO
+            | EXCEPTION_INT_OVERFLOW
+            | EXCEPTION_IN_PAGE_ERROR => {
+                // Generally these are all benign
+                // (IN_PAGE_ERROR *sounds* scary but it's basically the OS failing
+                // to load a swapped out page from the disk/network, which is about
+                // as scary as a power failure.)
+                exploitability_weight += TINY_BUMP;
+            }
+            EXCEPTION_ILLEGAL_INSTRUCTION
+            | EXCEPTION_FLT_INVALID_OPERATION
+            | EXCEPTION_PRIV_INSTRUCTION => {
+                // Illegal instructions are an indication that control flow
+                // has been corrupted.
+                exploitability_weight += LARGE_BUMP;
+            }
+            EXCEPTION_INVALID_DISPOSITION | EXCEPTION_NONCONTINUABLE_EXCEPTION => {
+                // Some exception handler has been misconfigured.
+                exploitability_weight += SMALL_BUMP;
+            }
+            EXCEPTION_GUARD_PAGE => {
+                // The good news is whatever guard page we tried to access
+                // did its job. The bad news is that we needed it.
+                // Probably a stack overflow, potentially a buffer overrun.
+                exploitability_weight += LARGE_BUMP;
+            }
+            EXCEPTION_ACCESS_VIOLATION => {
+                // Alright this is the Big Complicated one we're going to really drill into.
+                let near_null = crash_address <= PROBABLE_NULL_OFFSET;
+                let mut bad_read = false;
+                let mut bad_write = false;
+
+                // Get more precise information on the access violation
+                match crash_reason {
+                    CrashReason::WindowsAccessViolation(ExceptionCodeWindowsAccessType::READ) => {
+                        bad_read = true;
+                        exploitability_weight += if near_null { SMALL_BUMP } else { MEDIUM_BUMP };
+                    }
+                    CrashReason::WindowsAccessViolation(ExceptionCodeWindowsAccessType::WRITE) => {
+                        bad_write = true;
+                        exploitability_weight += if near_null { SMALL_BUMP } else { HUGE_BUMP };
+                    }
+                    CrashReason::WindowsAccessViolation(ExceptionCodeWindowsAccessType::EXEC) => {
+                        exploitability_weight += if near_null { SMALL_BUMP } else { HUGE_BUMP };
+                    }
+                    _ => {
+                        // This shouldn't happen, bail out
+                        warn!("Exploitability Analysis Encountered Malformed/Unknown EXCEPTION_ACCESS_VIOLATION");
+                        return None;
+                    }
+                }
+
+                if !near_null && address_is_ascii(crash_address) {
+                    // It's possible a string's contents are being interpretted
+                    // as a pointer, indicating we might be looking at an exploit widget.
+                    exploitability_weight += MEDIUM_BUMP;
+                }
+
+                memory.memory_at_address(instruction_ptr);
+                trace!(
+                    "Dissasembly not implemented, {} {} {}",
+                    bad_read,
+                    bad_write,
+                    DISSASSEMBLY_RANGE
+                );
+                // TODO: dissasemble the executable here and look for suspicious instructions
+            }
+            _ => {
+                // We have no opinion on the rest of these error codes
+            }
+        }
+    } else if let Some(ERROR_STACK_BUFFER_OVERRUN) = WinErrorWindows::from_u32(exception_code) {
+        // Well that's probably really bad
+        exploitability_weight += HUGE_BUMP;
+    } else if let Some(nt_status) = NtStatusWindows::from_u32(exception_code) {
+        match nt_status {
+            STATUS_STACK_BUFFER_OVERRUN | STATUS_HEAP_CORRUPTION => {
+                // Well that's probably really bad.
+                exploitability_weight += HUGE_BUMP;
+            }
+            _ => {}
+        }
+    }
+
+    Some(Exploitability::from_weight(exploitability_weight))
+}
+
+fn linux_exploitability(
+    state: &ProcessState,
+    _memory: &MinidumpMemoryList,
+) -> Option<Exploitability> {
+    use ExceptionCodeLinux::*;
+
+    let _crash_reason = state.crash_reason?;
+    let _crash_address = state.crash_address?;
+    let crashing_thread_id = state.requesting_thread?;
+    let crashing_thread = state.threads.get(crashing_thread_id)?;
+    let crashing_frame = crashing_thread.frames.first()?;
+    let _crashing_ctx = &crashing_frame.context;
+    let exception_code = state.exception_code?;
+
+    // `__stack_chk_fail` is a function in libc that's called if the program was compiled with
+    // `-fstack-protector` and a function's stack canary changes.
+    if let Some("__stack_chk_fail") = crashing_frame.function_name.as_deref() {
+        return Some(Exploitability::High);
+    }
+
+    // `__chk_fail` is a function in libc that's called if the program was compiled with
+    // `-D_FORTIFY_SOURCE=2`, a function like `strcpy()` is called, and the runtime
+    // can determine that the call would overflow the target buffer.
+    if let Some("__chk_fail") = crashing_frame.function_name.as_deref() {
+        return Some(Exploitability::High);
+    }
+
+    if let Some(signal) = ExceptionCodeLinux::from_u32(exception_code) {
+        match signal {
+            SIGHUP | SIGINT | SIGQUIT | SIGTRAP | SIGABRT | SIGFPE | SIGKILL | SIGUSR1
+            | SIGUSR2 | SIGPIPE | SIGALRM | SIGTERM | SIGCHLD | SIGCONT | SIGSTOP | SIGTSTP
+            | SIGTTIN | SIGTTOU | SIGURG | SIGXCPU | SIGXFSZ | SIGVTALRM | SIGPROF | SIGWINCH
+            | SIGIO | SIGPWR | SIGSYS | DUMP_REQUESTED => {
+                // These are all benign reasons to crash
+                return Some(Exploitability::None);
+            }
+            _ => { /* no opinion on these */ }
+        }
+    }
+
+    // TODO: parse MINIDUMP_STREAM_TYPE::LinuxMaps and analyze things like:
+    // * whether the instruction pointer was somewhere executable (bad if not)
+    // * whether the stack or heap was marked as executable (bad)
+    // * whether the stack pointer was in the stack (bad if not)
+
+    // TODO: dissasemble the executable here and look for suspicious instructions
+
+    // Conservatively assume this isn't exploitable, to avoid wasting people's time.
+    Some(Exploitability::None)
+}
+
+fn address_is_ascii(address: u64) -> bool {
+    for byte in &address.to_le_bytes() {
+        // Want to have a tighter range than Rust's is_ascii
+        let min_ascii = b' ';
+        let max_ascii = b'~';
+        let ascii_range = min_ascii..=max_ascii;
+        if !ascii_range.contains(byte) && *byte != 0 {
+            return false;
+        }
+    }
+    true
+}

--- a/minidump-processor/src/lib.rs
+++ b/minidump-processor/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod dwarf_symbolizer;
 mod evil;
+mod exploitability;
 mod process_state;
 mod processor;
 mod stackwalker;

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -64,6 +64,13 @@ minidump itself.\n\n\n")
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("guess-exploitability")
+                .long("guess-exploitability")
+                .takes_value(true)
+                .default_value("false")
+                .help("Whether to heuristically guess how exploitable the crash was.")
+        )
+        .arg(
             Arg::with_name("symbols-url")
                 .long_help("base URL from which URLs to symbol files can be constructed.
 
@@ -242,6 +249,7 @@ native debuginfo formats. We recommend using a version of dump_syms to generate 
     let mut options = ProcessorOptions::default();
 
     options.evil_json = matches.value_of_os("raw-json").map(Path::new);
+    options.guess_exploitability = matches.value_of("guess-exploitability").unwrap() == "true";
 
     let temp_dir = std::env::temp_dir();
 


### PR DESCRIPTION
Notably missing:

* anything that involves disassembling and analyzing the binary
* linux checks based on /proc/self/maps

I'm kinda bleh on how I just add the raw error code to the ProcessState -- maybe I should just pass it down directly? Or CrashReason should always make it easy to get?