### PR TITLE
Support printing out the contents of the thread names stream

### DIFF
--- a/minidump/src/bin/minidump_dump.rs
+++ b/minidump/src/bin/minidump_dump.rs
@@ -56,6 +56,9 @@ fn print_minidump_dump(path: &Path) {
             if let Ok(breakpad_info) = dump.get_stream::<MinidumpBreakpadInfo>() {
                 breakpad_info.print(stdout).unwrap();
             }
+            if let Ok(thread_names) = dump.get_stream::<MinidumpThreadNames>() {
+                thread_names.print(stdout).unwrap();
+            }
             // TODO: MemoryInfoList
             match dump.get_stream::<MinidumpCrashpadInfo>() {
                 Ok(crashpad_info) => crashpad_info.print(stdout).unwrap(),

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -1092,6 +1092,31 @@ impl MinidumpThreadNames {
             .get(&thread_id)
             .map(|name| Cow::Borrowed(&**name))
     }
+
+    /// Write a human-readable description of this `MinidumpThreadNames` to `f`.
+    pub fn print<T: Write>(&self, f: &mut T) -> io::Result<()> {
+        write!(
+            f,
+            "MinidumpThreadNames
+  thread_count = {}
+
+",
+            self.names.len()
+        )?;
+        for (i, (thread_id, name)) in self.names.iter().enumerate() {
+            writeln!(
+                f,
+                "thread_name[{}]
+MINIDUMP_THREAD_NAME
+  thread_id = {:#x}
+  name      = \"{}\"
+",
+                i, thread_id, name
+            )?;
+        }
+
+        Ok(())
+    }
 }
 
 impl MinidumpModuleList {


### PR DESCRIPTION
This is a simple patch to print out the thread names stream. I'm using it to test my macOS thread names' writer.