### PR TITLE
Implement LinuxMaps stream

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -7431,7 +7431,7 @@ pub struct MINIDUMP_MEMORY_INFO_LIST {
 /// This struct matches the [Microsoft struct][msdn] of the same name.
 ///
 /// [msdn]: https://docs.microsoft.com/en-us/windows/desktop/api/minidumpapiset/ns-minidumpapiset-_minidump_memory_info
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, PartialEq, Eq, Pread, SizeWith)]
 pub struct MINIDUMP_MEMORY_INFO {
     /// The base address of the region of pages
     pub base_address: u64,

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -165,9 +165,9 @@ where
         Err(_) => MinidumpUnloadedModuleList::new(),
     };
     let memory_list = dump.get_stream::<MinidumpMemoryList>().unwrap_or_default();
-    let _memory_info_list = dump
-        .get_stream::<MinidumpMemoryInfoList>()
-        .unwrap_or_default();
+    let memory_info_list = dump.get_stream::<MinidumpMemoryInfoList>().ok();
+    let linux_maps = dump.get_stream::<MinidumpLinuxMaps>().ok();
+    let _memory_info = UnifiedMemoryInfoList::new(memory_info_list, linux_maps).unwrap_or_default();
 
     // Get memory list
     let mut threads = vec![];


### PR DESCRIPTION
This is a dump of /proc/self/maps from the crashing process. Details on the format
included in the comments. Because this info does a similar thing to MinidumpMemoryInfoList
I have also introduced a UnifiedMemoryInfo type which you can use to wrap the two up
and not deal with the differences.

minidump_processor now reads both streams and sets up a UnifiedMemoryInfo, but it doesn't
yet do anything with it. Also did some cleanup on the previous patch that I noticed while
designing the unified API.

Part of #256