### PR TITLE
Stub out implementations of the stringy linux streams

### DIFF
--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -596,7 +596,7 @@ Unknown streams encountered:
                 "cpu_count": sys.cpu_count,
                 // TODO: Issue #19
                 // optional
-                "cpu_microcode_version": null,
+                "cpu_microcode_version": sys.cpu_microcode_version,
             },
             "crash_info": {
                 "type": self.crash_reason.map(|reason| reason.to_string()),

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -110,14 +110,20 @@ where
         .cpu_info()
         .map(|string| string.into_owned());
 
+    let linux_standard_base = dump.get_stream::<MinidumpLinuxLsbRelease>().ok();
+    let linux_cpu_info = dump.get_stream::<MinidumpLinuxCpuInfo>().ok();
+    let _linux_environ = dump.get_stream::<MinidumpLinuxEnviron>().ok();
+    let _linux_proc_status = dump.get_stream::<MinidumpLinuxProcStatus>().ok();
+
     let system_info = SystemInfo {
         os: dump_system_info.os,
         os_version: Some(os_version),
         cpu: dump_system_info.cpu,
         cpu_info,
+        cpu_microcode_version: linux_cpu_info.and_then(|info| info.microcode_version),
         cpu_count: dump_system_info.raw.number_of_processors as usize,
     };
-    let linux_standard_base = dump.get_stream::<MinidumpLinuxLsbRelease>().ok();
+
     let mac_crash_info = dump
         .get_stream::<MinidumpMacCrashInfo>()
         .ok()

--- a/minidump-processor/src/system_info.rs
+++ b/minidump-processor/src/system_info.rs
@@ -14,6 +14,8 @@ pub struct SystemInfo {
     ///
     /// For example,  "GenuineIntel level 6 model 13 stepping 8", if present.
     pub cpu_info: Option<String>,
+    /// The microcode version of the cpu
+    pub cpu_microcode_version: Option<u64>,
     /// The number of processors in the system
     ///
     /// Will be greater than one for multi-core systems.


### PR DESCRIPTION
Fixes #207

Adds implementations for:
* LinuxCpuInfo (/proc/cpuinfo)
* LinuxProcStatus (/proc/self/status)
* LinuxEnviron (/proc/self/environ)

The only new data we collect is LinuxCpuInfo.microcode_version, which gets fed through to
cpu_microcode_version in the json schema. All the code for the other streams is written,
so it should now be trivial to grab whatever key we decide is interesting with only a few
new lines.

LinuxAuxv, LinuxCmdLine and LinuxDsoDebug have been excluded from
this patchset as they all have more custom formats than the KEY SEPARATOR VALUE formats
of the implemented streams.

(This PR is built on top of the previous one to avoid merge conflicts, only the second patch is new.)