### PR TITLE
WIP stream dependencies

### DIFF
--- a/minidump/src/bin/minidump_dump.rs
+++ b/minidump/src/bin/minidump_dump.rs
@@ -31,10 +31,6 @@ fn print_minidump_dump(path: &Path) {
         Ok(dump) => {
             let stdout = &mut std::io::stdout();
             dump.print(stdout).unwrap();
-            // FIXME: doesn't handle the "bug" native windows minidumps have where
-            // the RVA is null but start_of_memory_range has a valid value we can
-            // use to get the memory range. This results in loss of missing
-            // thread memory dumps!
             if let Ok(thread_list) = dump.get_stream::<MinidumpThreadList<'_>>() {
                 thread_list.print(stdout).unwrap();
             }


### PR DESCRIPTION
Introduces the ability for a stream to statically depend on another, allowing stream parsing to be refined by the contents of other streams (e.g. using MinidumpMemoryList to repair thread stack pointers or MiscInfo to resolve CpuContexts).