### PR TITLE
WIP Lazily parse stack memory and cpu contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ It's fairly heavily modeled after the [Google Breakpad](https://chromium.googles
 Print the raw details of the exception stream from a minidump:
 
 ```rust
-use minidump::{Error, Minidump, MinidumpException, MinidumpStream};
+use minidump::{Error, Minidump, MinidumpMiscInfo, MinidumpSystemInfo, MinidumpException, MinidumpStream};
 use std::io::{self, Write};
 
 fn work() -> Result<(), Error> {
   let mut dump = minidump::Minidump::read_path("../testdata/test.dmp")?;
+  let system_info: Option<MinidumpSystemInfo> = dump.get_stream().ok();
+  let misc_info: Option<MinidumpMiscInfo> = dump.get_stream().ok();
   let exception: MinidumpException = dump.get_stream()?;
-  drop(exception.print(&mut io::stdout()));
+  drop(exception.print(&mut io::stdout(), system_info.as_ref(), misc_info.as_ref()));
   Ok(())
 }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,10 @@ Changes:
 
 New features:
 
+* GetLastError
+    * MinidumpThread now has a method to retrieve the thread's GetLastError value
+    * We now parse more Windows error codes
+
 * MemoryInfo:
     * MemoryInfoListStream has been implemented (as `MinidumpMemoryInfoList`)
         * Provides metadata on the mapped memory regions like "was executable" or "was it freed"
@@ -35,6 +39,9 @@ New features:
 
 Improvements:
 
+* Contexts with XSTATE are now properly parsed.
+    * (although we still ignore the XSTATE data, but previously we would have returned an error)
+* minidump_dump now properly handles bad stack RVAs properly.
 * MinidumpSystemInfo::csd_version now works
     * Was reading its value from the wrong array *shrug*
     * This also improves minidump processor's `os_ver` string (now at parity with breakpad)
@@ -45,6 +52,13 @@ Improvements:
 
 Breaking changes:
 
+* `MinidumpThread` and `MinidumpException` now lazily parse their `context` value (and `stack` for
+`MinidumpThread`).
+    * This is because these values cannot be reliable parsed without access to other streams.
+    * These fields have been private, in favour of accessors which require the other streams
+    necessary to properly parse them.
+    * `print` functionality for them (and `MinidumpThreadList`) now also takes those values.
+    * For most users this won't be a big deal since you'll want all the dependent streams anyway.
 * Some explicitly typed iterators have been replaced with `impl Iterator`
     * These were always supposed to be like that, this code just pre-existed the feature
     * Comes with minor efficiency win because they were internally boxed and dynamically dispatched(!) to simulate `impl Iterator`.
@@ -55,6 +69,11 @@ Breaking changes:
 
 ## minidump-stack/minidump-processor/breakpad-symbols
 
+Thread names:
+
+* Now can retrieve thread names from the evil_json (if this means nothing to you, don't worry about it.)
+
+
 Symbol cache:
 
 * Now writes (and reads back) an `INFO URL` line to the symbol file
@@ -63,14 +82,22 @@ Symbol cache:
 
 Json schema:
 
+* Now properly populates the `thread.last_error_value` field
 * Now properly populates the `system_info.cpu_microcode` field (using `LinuxCpuInfoStream`)
 * `system_info.os_ver` now includes the contents of `MinidumpSystemInfo::csd_version` (as intended)
 
 
+Breaking changes:
 
-## minidump-common/minidump-tools
+* `process_minidump_with_evil` has been replaced with the more general `process_minidump_with_options`
 
-No changes
+
+
+## minidump-common
+
+* More Windows error type definitions
+* CONTEXT_HAS_XSTATE value added
+* doc cleanups
 
 
 

--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -6797,6 +6797,9 @@ pub enum ExceptionCodeMacResourceThreadsFlavor {
 
 /// Valid bits in a `context_flags` for [`ContextFlagsCpu`]
 pub const CONTEXT_CPU_MASK: u32 = 0xffffff00;
+/// x86 and x64 contexts have this bit set in their `context_flags` when they have
+/// extra XSTATE beyond the traditional context definition.
+pub const CONTEXT_HAS_XSTATE: u32 = 0x00000040;
 
 bitflags! {
     /// CPU type values in the `context_flags` member of `CONTEXT_` structs

--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -7510,18 +7510,55 @@ multi_structs! {
         pub xstate_data: XSTATE_CONFIG_FEATURE_MSC_INFO,
         pub process_cookie: u32,
     }
-    // TODO: read xstate_data and process the extra XSAVE sections at the
-    // end of each thread's cpu context.
 }
 
-/// A descriptor of the XSAVE context which can be found at the end of
-/// each thread's cpu context.
+/// A descriptor of the XSAVE context, which extends a normal x86/x64 context.
 ///
 /// The sections of this context are dumps of some of the CPUs registers
 /// (e.g. one section might contain the contents of the SSE registers).
 ///
 /// Intel documents its XSAVE entries in Volume 1, Chapter 13 of the
 /// "Intel 64 and IA-32 Architectures Software Developer’s Manual".
+///
+///
+/// # The XSTATE Format in Minidumps
+///
+/// This format is slightly messed up in the context of minidumps because it's
+/// grafted onto Microsoft's own formats. Here's what's important to know:
+///
+/// * The "Cpu Context" and the "XSAVE context" are in fact the same regions
+/// of memory.
+///
+/// * Whether XSTATE is present or not, the classic layouts of CONTEXT_X86
+/// and [`CONTEXT_AMD64`] both apply -- xstate will only add stuff after *or*
+/// refine your understanding of memory in the existing layout. So you can
+/// safely ignore the existence of XSTATE, but you might be missing new info.
+///
+/// * AMD64 doesn't have a standard way to save general purpose registers,
+/// so the first 256 bytes of [`CONTEXT_AMD64`] are just however microsoft
+/// decided to save the registers, and will not be referred to by the XSTATE.
+///
+/// **!!! THIS PART IS IMPORTANT !!!**
+///
+/// * As a consequence, all [`XSTATE_FEATURE::offset`] values must have 256
+/// added to them to get the correct offset for that feature! For example, the
+/// LEGACY_FLOATING_POINT feature should always have an offset of 0, but it
+/// is actually at offset 256 in [`CONTEXT_AMD64`] (it corresponds to
+/// [`CONTEXT_AMD64::float_save`]).
+///
+/// * The following features are already contained inside of [`CONTEXT_AMD64`]:
+///    * LEGACY_FLOATING_POINT
+///    * LEGACY_SSE
+///    * GSSE_AND_AVX
+///
+/// * If there are XSTATE entries that *actually* map outside of the context's
+/// normal memory range, then the context's [`context_flags`](`CONTEXT_AMD64::context_flags`)
+/// will have bit 0x40 set ([`CONTEXT_HAS_XSTATE`]).
+///
+/// * [`ContextFlagsCpu::from_flags`] will mask out the [`CONTEXT_HAS_XSTATE`] bit.
+/// If you want to check for that bit, check the raw value of
+/// [`context_flags`](`CONTEXT_AMD64::context_flags`).
+
 #[derive(Debug, Clone, Pread, SizeWith)]
 pub struct XSTATE_CONFIG_FEATURE_MSC_INFO {
     /// The size of this struct.
@@ -7612,6 +7649,9 @@ impl XstateFeatureIndex {
 #[derive(Clone, Copy, Debug, Default, Pread, SizeWith, PartialEq, Eq)]
 pub struct XSTATE_FEATURE {
     /// This entry's offset from the start of the context (in bytes).
+    ///
+    /// NOTE: THIS VALUE IS A LIE. At least on AMD64 you need to add 256
+    /// to this! See the docs of [`XSTATE_CONFIG_FEATURE_MSC_INFO`].
     pub offset: u32,
     /// This entry's size (in bytes).
     pub size: u32,

--- a/minidump/src/context.rs
+++ b/minidump/src/context.rs
@@ -11,6 +11,7 @@ use std::io::prelude::*;
 use std::mem;
 
 use crate::iostuff::*;
+use crate::{MinidumpMiscInfo, MinidumpSystemInfo};
 use minidump_common::format as md;
 use minidump_common::format::ContextFlagsCpu;
 
@@ -579,7 +580,12 @@ impl MinidumpContext {
     }
 
     /// Read a `MinidumpContext` from `bytes`.
-    pub fn read(bytes: &[u8], endian: scroll::Endian) -> Result<MinidumpContext, ContextError> {
+    pub fn read(
+        bytes: &[u8],
+        endian: scroll::Endian,
+        _system_info: &MinidumpSystemInfo,
+        _misc: Option<&MinidumpMiscInfo>,
+    ) -> Result<MinidumpContext, ContextError> {
         // Some contexts don't have a context flags word at the beginning,
         // so special-case them by size.
         let mut offset = 0;

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -5469,7 +5469,8 @@ c70206ca83eb2852-de0206ca83eb2852  -w-s  10bac9000 fd:05 1196511 /usr/lib64/libt
             Section::with_endian(Endian::Little).append_repeated(0, 0x1000),
             0x1000,
         );
-        let system_info = SystemInfo::new(Endian::Little);
+        let arch = md::ProcessorArchitecture::PROCESSOR_ARCHITECTURE_INTEL as u16;
+        let system_info = SystemInfo::new(Endian::Little).set_processor_architecture(arch);
         let thread = Thread::new(Endian::Little, 0x1234, &stack, &context);
         let dump = SynthMinidump::with_endian(Endian::Little)
             .add_thread(thread)
@@ -5506,7 +5507,8 @@ c70206ca83eb2852-de0206ca83eb2852  -w-s  10bac9000 fd:05 1196511 /usr/lib64/libt
             Section::with_endian(Endian::Little).append_repeated(0, 0x1000),
             0x1000000010000000,
         );
-        let system_info = SystemInfo::new(Endian::Little);
+        let arch = md::ProcessorArchitecture::PROCESSOR_ARCHITECTURE_AMD64 as u16;
+        let system_info = SystemInfo::new(Endian::Little).set_processor_architecture(arch);
         let thread = Thread::new(Endian::Little, 0x1234, &stack, &context);
         let dump = SynthMinidump::with_endian(Endian::Little)
             .add_thread(thread)

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -1875,7 +1875,7 @@ impl<'a> MinidumpLinuxMapInfo<'a> {
         //
         // ```
         //
-        // * address: the start and end addresses (TODO: inclusive?)
+        // * address: the start and end addresses (inclusive)
         // * perms: permissions the process had on the memory
         //   * r = read
         //   * w = write
@@ -2017,7 +2017,6 @@ impl<'a> MinidumpLinuxMapInfo<'a> {
     }
     /// Write a human-readable description of this.
     pub fn print<T: Write>(&self, f: &mut T) -> io::Result<()> {
-        // TODO permissions
         write!(
             f,
             "MINIDUMP_LINUX_MAP_INFO
@@ -3172,7 +3171,6 @@ impl MinidumpMiscInfo {
                         write!(f, "    feature {:2} - (unknown)           : ", i)?;
                     }
                     writeln!(f, " offset {:4}, size {:4}", feature.offset, feature.size)?;
-                    // TODO: load the XSAVE state and print it?
                 }
             }
             None => writeln!(f, "(invalid)")?,

--- a/synth-minidump/src/lib.rs
+++ b/synth-minidump/src/lib.rs
@@ -27,6 +27,7 @@ pub struct SynthMinidump {
     stream_directory_rva: Label,
     /// The contents of the stream directory.
     stream_directory: Section,
+    /// System info (cpu arch, os, etc.)
     system_info: Option<SystemInfo>,
     /// List of modules in this minidump.
     module_list: Option<ListStream<Module>>,
@@ -1684,6 +1685,11 @@ impl SystemInfo {
                 amd_extended_cpu_features: 0,
             },
         }
+    }
+
+    pub fn set_processor_architecture(mut self, arch: u16) -> Self {
+        self.processor_architecture = arch;
+        self
     }
 }
 


### PR DESCRIPTION
This is an alternative version of #278, which instead of weird magic traits that will do double-parsing behind your back, we just defer parsing the context/stack_memory until the user requests them, at which point we can demand dependent streams to do the task properly. I realized this was a reasonable approach when I made a similar api for #286.

Using this info for contexts is only stubbed out, but stack repair is implemented.

This is basically no extra burden to a legitimate user since they're going to want to parse out MemoryList and SystemInfo, and MiscInfo is optional. It's slightly more annoying for tests because we need to mock SystemInfo. For now I used the sloppy garbage SystemInfo I made for Linux integration tests in `processor`. I'll deal with it when I implement actually using the SystemInfo (and presumably break the tests).

Biggest "problem" is that this breaks the encapsulation of `print`, but since those are basically only there for dump_syms and aren't actually part of a trait or anything, we could just make them arguments to those print methods.

This is also more forwards compatible than #278 because we can introduce new methods that take additional arguments if we find places where analysis needs to be refined more.
