### PR TITLE
Add a timeout to symbol downloads

### DIFF
--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -42,6 +42,7 @@ use std::fmt;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 pub use minidump_common::traits::Module;
 
@@ -348,8 +349,9 @@ impl HttpSymbolSupplier {
         cache: PathBuf,
         tmp: PathBuf,
         mut local_paths: Vec<PathBuf>,
+        timeout: Duration,
     ) -> HttpSymbolSupplier {
-        let client = Client::new();
+        let client = Client::builder().timeout(timeout).build().unwrap();
         let urls = urls
             .into_iter()
             .filter_map(|mut u| {

--- a/minidump-processor/src/symbols.rs
+++ b/minidump-processor/src/symbols.rs
@@ -74,6 +74,7 @@ mod symbols_shim {
     use minidump::Module;
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::time::Duration;
     impl SymbolProvider for Symbolizer {
         fn fill_symbol(
             &self,
@@ -98,12 +99,14 @@ mod symbols_shim {
         symbol_urls: Vec<String>,
         symbols_cache: PathBuf,
         symbols_tmp: PathBuf,
+        timeout: Duration,
     ) -> impl SymbolSupplier {
         breakpad_symbols::HttpSymbolSupplier::new(
             symbol_urls,
             symbols_cache,
             symbols_tmp,
             symbol_paths,
+            timeout,
         )
     }
 
@@ -127,6 +130,7 @@ mod symbols_shim {
     use minidump::Module;
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::time::Duration;
 
     // Import symbolic here
 
@@ -253,6 +257,7 @@ mod symbols_shim {
         _symbol_urls: Vec<String>,
         _symbols_cache: PathBuf,
         _symbols_tmp: PathBuf,
+        _timeout: Duration,
     ) -> impl SymbolSupplier {
         HttpSymbolSupplier {}
     }

--- a/minidump-tools/src/lib.rs
+++ b/minidump-tools/src/lib.rs
@@ -6,6 +6,7 @@ use reqwest::blocking::Client;
 use std::env;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use structopt::StructOpt;
 
 use breakpad_symbols::{HttpSymbolSupplier, SimpleFrame, Symbolizer};
@@ -218,7 +219,13 @@ fn handle_symbol_paths(symbol_paths: Vec<PathBuf>) -> Result<Symbolizer, Error> 
             .collect();
         (paths, urls)
     };
-    let supplier = HttpSymbolSupplier::new(symbol_urls, tmp_symbols_path, tmp_path, symbol_paths);
+    let supplier = HttpSymbolSupplier::new(
+        symbol_urls,
+        tmp_symbols_path,
+        tmp_path,
+        symbol_paths,
+        Duration::from_secs(1000),
+    );
     Ok(Symbolizer::new(supplier))
 }
 


### PR DESCRIPTION
This also introduces a --symbol-download-timeout-secs flag to minidump-stackwalk
so it's configurable. The default is 1000 seconds (which for a 300MB .sym file
requires a connection speed of 300KB/s).

Weirdly I think adding the timeout at all seems to unstick the download, but I'm
not sure. Either way you can tune the value to your needs.

Fixes #300