### PR TITLE
Give better feedback on corrupt minidumps 

### DIFF
--- a/minidump/src/bin/minidump_dump.rs
+++ b/minidump/src/bin/minidump_dump.rs
@@ -99,7 +99,7 @@ fn print_minidump_dump(path: &Path) {
         }
         Err(err) => {
             let mut stderr = std::io::stderr();
-            writeln!(&mut stderr, "Error reading dump: {:?}", err).unwrap();
+            writeln!(&mut stderr, "Error reading dump: {}", err).unwrap();
         }
     }
 }


### PR DESCRIPTION
Our error types have Display strings but we weren't using them. For a couple strings
I've added a parenthetical hint, reflecting the common cause of these two errors
(from what I'm seeing in socorro).

I've also added some `warn`s for duplicate entries, to hopefully make it easier
to notice when this happens. In particular socorro gets many MissingThreadList
minidumps which are just full of 13 dummy UnusedStream entries. Looking at the
minidump in minidump_dump is really confusing, because it says there's 13 but
only prints 1. The logs now make it clearer, as you see several copies of:

```
[WARN] Minidump contains multiple streams of type 0 (UnusedStream) at indices 0 (0 bytes) and 1 (0 bytes) (using 1)
```

(It will still be confusing to look at in minidump_dump, we should really hook it
up with proper logging...)