### PR TITLE
0.9.5 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "breakpad-symbols"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "failure",
  "log",
@@ -607,7 +607,7 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minidump"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "chrono",
  "doc-comment",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "minidump-common"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "bitflags",
  "enum-primitive-derive",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "minidump-processor"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "breakpad-symbols",
  "chrono",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "minidump-stackwalk"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "clap",
  "log",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "synth-minidump"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "encoding",
  "minidump-common",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,8 +1,13 @@
-# Pending Release (TBD)
+# Version 0.9.5 (2021-12-01)
 
-Commit: TBD
+Commit: this one!
 
-Bugfixes, testing, docs!
+The JSON schema and minidump-stackwalk CLI are now stabilized. They are now
+reasonable to rely on in production (only reason we would break them is if
+we ran into a nasty bug).
+
+This release also adds a ton of documentation! (But there can always be more...)
+
 
 
 Changes:
@@ -12,6 +17,7 @@ Changes:
 Lots more documentation.
 
 ## minidump-stackwalk/minidump-processor
+
 
 Breaking changes:
 
@@ -23,6 +29,7 @@ Breaking changes:
     * `frames_truncated` removed because it was always `false`
     * `total_frames` removed because it was always the same as `frame_count`
     * Both were for a misfeature of a previous incarnation of minidump-stackwalk that we won't implement
+
 
 New features:
 

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "breakpad-symbols"
 description = "A library for working with Google Breakpad's text-format symbol files."
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "MIT"
 readme = "README.md"
@@ -14,7 +14,7 @@ edition = "2018"
 travis-ci = { repository = "luser/rust-minidump" }
 
 [dependencies]
-minidump-common = { version = "0.9.4", path = "../minidump-common" }
+minidump-common = { version = "0.9.5", path = "../minidump-common" }
 range-map = "0.1.5"
 nom = "~1.2.2"
 log = "0.4.1"

--- a/minidump-common/Cargo.toml
+++ b/minidump-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minidump-common"
 description = "Some common types for working with minidump files."
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 readme = "README.md"
 license = "MIT"

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minidump-processor"
 description = "A library and tool for producing stack traces and other useful information from minidump files."
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "MIT"
 readme = "README.md"
@@ -20,13 +20,13 @@ breakpad-syms = ["breakpad-symbols"]
 symbolic-syms = []
 
 [dependencies]
-breakpad-symbols = { version = "0.9.4", path = "../breakpad-symbols", optional = true }
+breakpad-symbols = { version = "0.9.5", path = "../breakpad-symbols", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
 clap = "2.33"
 failure = "0.1.1"
 log = "0.4"
 memmap = "0.7.0"
-minidump = { version = "0.9.4", path = "../minidump" }
+minidump = { version = "0.9.5", path = "../minidump" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.11.0"

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minidump-stackwalk"
 description = "A CLI minidump analyzer"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "MIT"
 homepage = "https://github.com/luser/rust-minidump"
@@ -17,8 +17,8 @@ travis-ci = { repository = "luser/rust-minidump" }
 [dependencies]
 clap = { version = "2.33", features=["wrap_help"] }
 log = "0.4"
-minidump = { version = "0.9.4", path = "../minidump" }
-minidump-processor = { version = "0.9.4", path = "../minidump-processor" }
+minidump = { version = "0.9.5", path = "../minidump" }
+minidump-processor = { version = "0.9.5", path = "../minidump-processor" }
 simplelog = "0.11.0"
 
 [features]

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minidump"
 description = "A parser for the minidump format."
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "MIT"
 homepage = "https://github.com/luser/rust-minidump"
@@ -15,7 +15,7 @@ edition = "2018"
 failure = "0.1.1"
 range-map = "0.1.5"
 log = "0.4.1"
-minidump-common = { version = "0.9.4", path = "../minidump-common" }
+minidump-common = { version = "0.9.5", path = "../minidump-common" }
 num-traits = "0.2"
 encoding = "0.2"
 chrono = "0.4.6"

--- a/synth-minidump/Cargo.toml
+++ b/synth-minidump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synth-minidump"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 readme = "README.md"
 
@@ -8,6 +8,6 @@ readme = "README.md"
 
 [dependencies]
 test-assembler = "0.1.5"
-minidump-common = { version = "0.9.4", path = "../minidump-common" }
+minidump-common = { version = "0.9.5", path = "../minidump-common" }
 encoding = "0.2"
 scroll = "0.10.2"


### PR DESCRIPTION
The JSON schema and minidump-stackwalk CLI are now stabilized. They are now
reasonable to rely on in production (only reason we would break them is if
we ran into a nasty bug).

This release also adds a ton of documentation! (But there can always be more...)

See RELEASES.md for details