### PR TITLE
WIP make symbolication async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +83,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "breakpad-symbols"
 version = "0.9.6"
 dependencies = [
+ "async-trait",
  "circular",
  "log",
  "minidump-common",
@@ -80,6 +92,7 @@ dependencies = [
  "reqwest",
  "tempfile",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -360,12 +373,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
-name = "futures-io"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
-
-[[package]]
 name = "futures-sink"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,12 +391,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -587,6 +591,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
+name = "lock_api"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +672,7 @@ dependencies = [
 name = "minidump-processor"
 version = "0.9.6"
 dependencies = [
+ "async-trait",
  "breakpad-symbols",
  "clap",
  "doc-comment",
@@ -671,6 +685,7 @@ dependencies = [
  "synth-minidump",
  "test-assembler",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -686,6 +701,7 @@ dependencies = [
  "simplelog",
  "synth-minidump",
  "test-assembler",
+ "tokio",
 ]
 
 [[package]]
@@ -850,6 +866,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1014,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "scroll"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
+checksum = "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1007,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
+checksum = "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1071,6 +1118,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1148,12 @@ name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "smart-default"
@@ -1271,8 +1333,23 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ use minidump::Minidump;
 use minidump_processor::{http_symbol_supplier, ProcessorOptions, Symbolizer};
 use serde_json::Value;
 
-fn main() -> Result<(), ()> {
+#[tokio::main]
+async fn main() -> Result<(), ()> {
     // Read the minidump
     let dump = Minidump::read_path("../testdata/test.dmp").map_err(|_| ())?;
  
@@ -77,6 +78,7 @@ fn main() -> Result<(), ()> {
     ));
  
     let state = minidump_processor::process_minidump_with_options(&dump, &provider, options)
+        .await
         .map_err(|_| ())?;
 
     // Write the JSON output to an arbitrary writer (here, a Vec).

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -14,15 +14,19 @@ edition = "2018"
 travis-ci = { repository = "luser/rust-minidump" }
 
 [dependencies]
+async-trait = "0.1.51"
 circular = "0.3.0"
 minidump-common = { version = "0.9.6", path = "../minidump-common" }
 range-map = "0.1.5"
 nom = "~1.2.2"
 log = "0.4.1"
-reqwest = { version = "0.11.6", features = ["blocking", "gzip"] }
+reqwest = { version = "0.11.6", features = ["gzip"] }
 tempfile = "3.3.0"
 thiserror = "1.0.30"
 
 # Private API, only here to support the fuzzer
 [features]
 fuzz = []
+
+[dev-dependencies]
+tokio =  { version = "1.12.0", features = ["full"] }

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -20,6 +20,7 @@ breakpad-syms = ["breakpad-symbols"]
 symbolic-syms = []
 
 [dependencies]
+async-trait = "0.1.51"
 breakpad-symbols = { version = "0.9.6", path = "../breakpad-symbols", optional = true }
 clap = "2.34"
 log = "0.4"
@@ -34,3 +35,4 @@ thiserror = "1.0.30"
 test-assembler = "0.1.6"
 synth-minidump = { path = "../synth-minidump" }
 doc-comment = "0.3.3"
+tokio =  { version = "1.12.0", features = ["full"] }

--- a/minidump-processor/README.md
+++ b/minidump-processor/README.md
@@ -20,7 +20,8 @@ use minidump::Minidump;
 use minidump_processor::{http_symbol_supplier, ProcessorOptions, Symbolizer};
 use serde_json::Value;
 
-fn main() -> Result<(), ()> {
+#[tokio::main]
+async fn main() -> Result<(), ()> {
     // Read the minidump
     let dump = Minidump::read_path("../testdata/test.dmp").map_err(|_| ())?;
  
@@ -45,6 +46,7 @@ fn main() -> Result<(), ()> {
     ));
  
     let state = minidump_processor::process_minidump_with_options(&dump, &provider, options)
+        .await
         .map_err(|_| ())?;
 
     // Write the JSON output to an arbitrary writer (here, a Vec).

--- a/minidump-processor/src/lib.rs
+++ b/minidump-processor/src/lib.rs
@@ -21,7 +21,8 @@
 //! use minidump_processor::{http_symbol_supplier, ProcessorOptions, Symbolizer};
 //! use serde_json::Value;
 //!  
-//! fn main() -> Result<(), ()> {
+//! #[tokio::main]
+//! async fn main() -> Result<(), ()> {
 //!     // Read the minidump
 //!     let dump = Minidump::read_path("../testdata/test.dmp").map_err(|_| ())?;
 //!  
@@ -46,6 +47,7 @@
 //!     ));
 //!  
 //!     let state = minidump_processor::process_minidump_with_options(&dump, &provider, options)
+//!         .await
 //!         .map_err(|_| ())?;
 //!  
 //!     // Write the JSON output to an arbitrary writer (here, a Vec).

--- a/minidump-processor/src/stackwalker/amd64.rs
+++ b/minidump-processor/src/stackwalker/amd64.rs
@@ -26,16 +26,16 @@ const FRAME_POINTER_REGISTER: &str = "rbp";
 // FIXME: rdi and rsi are also preserved on windows (but not in sysv) -- we should handle that?
 const CALLEE_SAVED_REGS: &[&str] = &["rbx", "rbp", "r12", "r13", "r14", "r15"];
 
-fn get_caller_by_cfi<P>(
+async fn get_caller_by_cfi<P>(
     ctx: &CONTEXT_AMD64,
     callee: &StackFrame,
     grand_callee: Option<&StackFrame>,
-    stack_memory: &MinidumpMemory,
+    stack_memory: &MinidumpMemory<'_>,
     modules: &MinidumpModuleList,
     symbol_provider: &P,
 ) -> Option<StackFrame>
 where
-    P: SymbolProvider,
+    P: SymbolProvider + Sync,
 {
     trace!("unwind: trying cfi");
 
@@ -66,7 +66,9 @@ where
         stack_memory,
     };
 
-    symbol_provider.walk_frame(module, &mut stack_walker)?;
+    symbol_provider
+        .walk_frame(module, &mut stack_walker)
+        .await?;
     let caller_ip = stack_walker.caller_ctx.rip;
     let caller_sp = stack_walker.caller_ctx.rsp;
 
@@ -104,12 +106,12 @@ fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static st
 fn get_caller_by_frame_pointer<P>(
     ctx: &CONTEXT_AMD64,
     callee: &StackFrame,
-    stack_memory: &MinidumpMemory,
+    stack_memory: &MinidumpMemory<'_>,
     _modules: &MinidumpModuleList,
     _symbol_provider: &P,
 ) -> Option<StackFrame>
 where
-    P: SymbolProvider,
+    P: SymbolProvider + Sync,
 {
     trace!("unwind: trying frame pointer");
     if let MinidumpContextValidity::Some(ref which) = callee.context.valid {
@@ -202,15 +204,15 @@ where
     Some(StackFrame::from_context(context, FrameTrust::FramePointer))
 }
 
-fn get_caller_by_scan<P>(
+async fn get_caller_by_scan<P>(
     ctx: &CONTEXT_AMD64,
     callee: &StackFrame,
-    stack_memory: &MinidumpMemory,
+    stack_memory: &MinidumpMemory<'_>,
     modules: &MinidumpModuleList,
     symbol_provider: &P,
 ) -> Option<StackFrame>
 where
-    P: SymbolProvider,
+    P: SymbolProvider + Sync,
 {
     trace!("unwind: trying scan");
     // Stack scanning is just walking from the end of the frame until we encounter
@@ -250,7 +252,7 @@ where
     for i in 0..scan_range {
         let address_of_ip = last_sp.checked_add(i * POINTER_WIDTH)?;
         let caller_ip = stack_memory.get_memory_at_address(address_of_ip as u64)?;
-        if instruction_seems_valid(caller_ip, modules, symbol_provider) {
+        if instruction_seems_valid(caller_ip, modules, symbol_provider).await {
             // ip is pushed by CALL, so sp is just address_of_ip + ptr
             let caller_sp = address_of_ip.checked_add(POINTER_WIDTH)?;
 
@@ -352,25 +354,25 @@ where
 /// If we applied this more rigorous validation to cfi/fp methods, we
 /// would just discard the correct register values from the known frame
 /// and immediately start doing unreliable scans.
-fn instruction_seems_valid<P>(
+async fn instruction_seems_valid<P>(
     instruction: Pointer,
     modules: &MinidumpModuleList,
     symbol_provider: &P,
 ) -> bool
 where
-    P: SymbolProvider,
+    P: SymbolProvider + Sync,
 {
     if is_non_canonical(instruction) || instruction == 0 {
         return false;
     }
 
-    super::instruction_seems_valid_by_symbols(instruction as u64, modules, symbol_provider)
+    super::instruction_seems_valid_by_symbols(instruction as u64, modules, symbol_provider).await
 }
 
 fn stack_seems_valid(
     caller_sp: Pointer,
     callee_sp: Pointer,
-    stack_memory: &MinidumpMemory,
+    stack_memory: &MinidumpMemory<'_>,
 ) -> bool {
     // The stack shouldn't *grow* when we unwind
     if caller_sp <= callee_sp {
@@ -399,55 +401,62 @@ fn is_non_canonical(ptr: Pointer) -> bool {
     ptr > 0x7FFFFFFFFFFF && ptr < 0xFFFF800000000000
 }
 
+#[async_trait::async_trait]
 impl Unwind for CONTEXT_AMD64 {
-    fn get_caller_frame<P>(
+    async fn get_caller_frame<P>(
         &self,
         callee: &StackFrame,
         grand_callee: Option<&StackFrame>,
-        stack_memory: Option<&MinidumpMemory>,
+        stack_memory: Option<&MinidumpMemory<'_>>,
         modules: &MinidumpModuleList,
         syms: &P,
     ) -> Option<StackFrame>
     where
-        P: SymbolProvider,
+        P: SymbolProvider + Sync,
     {
-        stack_memory
-            .as_ref()
-            .and_then(|stack| {
-                get_caller_by_cfi(self, callee, grand_callee, stack, modules, syms)
-                    .or_else(|| get_caller_by_frame_pointer(self, callee, stack, modules, syms))
-                    .or_else(|| get_caller_by_scan(self, callee, stack, modules, syms))
-            })
-            .and_then(|mut frame| {
-                // We now check the frame to see if it looks like unwinding is complete,
-                // based on the frame we computed having a nonsense value. Returning
-                // None signals to the unwinder to stop unwinding.
+        let stack = stack_memory.as_ref()?;
 
-                // if the instruction is within the first ~page of memory, it's basically
-                // null, and we can assume unwinding is complete.
-                if frame.context.get_instruction_pointer() < 4096 {
-                    trace!("unwind: instruction pointer was nullish, assuming unwind complete");
-                    return None;
-                }
-                // If the new stack pointer is at a lower address than the old,
-                // then that's clearly incorrect. Treat this as end-of-stack to
-                // enforce progress and avoid infinite loops.
-                if frame.context.get_stack_pointer() <= self.rsp {
-                    trace!("unwind: stack pointer went backwards, assuming unwind complete");
-                    return None;
-                }
+        // .await doesn't like closures, so don't use Option chaining
+        let mut frame = None;
+        if frame.is_none() {
+            frame = get_caller_by_cfi(self, callee, grand_callee, stack, modules, syms).await;
+        }
+        if frame.is_none() {
+            frame = get_caller_by_frame_pointer(self, callee, stack, modules, syms);
+        }
+        if frame.is_none() {
+            frame = get_caller_by_scan(self, callee, stack, modules, syms).await;
+        }
+        let mut frame = frame?;
 
-                // Ok, the frame now seems well and truly valid, do final cleanup.
+        // We now check the frame to see if it looks like unwinding is complete,
+        // based on the frame we computed having a nonsense value. Returning
+        // None signals to the unwinder to stop unwinding.
 
-                // A caller's ip is the return address, which is the instruction
-                // *after* the CALL that caused us to arrive at the callee. Set
-                // the value to one less than that, so it points within the
-                // CALL instruction. This is important because we use this value
-                // to lookup the CFI we need to unwind the next frame.
-                let ip = frame.context.get_instruction_pointer() as u64;
-                frame.instruction = ip - 1;
+        // if the instruction is within the first ~page of memory, it's basically
+        // null, and we can assume unwinding is complete.
+        if frame.context.get_instruction_pointer() < 4096 {
+            trace!("unwind: instruction pointer was nullish, assuming unwind complete");
+            return None;
+        }
+        // If the new stack pointer is at a lower address than the old,
+        // then that's clearly incorrect. Treat this as end-of-stack to
+        // enforce progress and avoid infinite loops.
+        if frame.context.get_stack_pointer() <= self.rsp {
+            trace!("unwind: stack pointer went backwards, assuming unwind complete");
+            return None;
+        }
 
-                Some(frame)
-            })
+        // Ok, the frame now seems well and truly valid, do final cleanup.
+
+        // A caller's ip is the return address, which is the instruction
+        // *after* the CALL that caused us to arrive at the callee. Set
+        // the value to one less than that, so it points within the
+        // CALL instruction. This is important because we use this value
+        // to lookup the CFI we need to unwind the next frame.
+        let ip = frame.context.get_instruction_pointer() as u64;
+        frame.instruction = ip - 1;
+
+        Some(frame)
     }
 }

--- a/minidump-processor/src/stackwalker/arm.rs
+++ b/minidump-processor/src/stackwalker/arm.rs
@@ -26,16 +26,16 @@ const PROGRAM_COUNTER: &str = Registers::ProgramCounter.name();
 const LINK_REGISTER: &str = Registers::LinkRegister.name();
 const CALLEE_SAVED_REGS: &[&str] = &["r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11"];
 
-fn get_caller_by_cfi<P>(
+async fn get_caller_by_cfi<P>(
     ctx: &ArmContext,
     callee: &StackFrame,
     grand_callee: Option<&StackFrame>,
-    stack_memory: &MinidumpMemory,
+    stack_memory: &MinidumpMemory<'_>,
     modules: &MinidumpModuleList,
     symbol_provider: &P,
 ) -> Option<StackFrame>
 where
-    P: SymbolProvider,
+    P: SymbolProvider + Sync,
 {
     trace!("unwind: trying cfi");
     let valid = &callee.context.valid;
@@ -59,7 +59,9 @@ where
         stack_memory,
     };
 
-    symbol_provider.walk_frame(module, &mut stack_walker)?;
+    symbol_provider
+        .walk_frame(module, &mut stack_walker)
+        .await?;
     let caller_pc = stack_walker.caller_ctx.get_register_always(PROGRAM_COUNTER);
     let caller_sp = stack_walker.caller_ctx.get_register_always(STACK_POINTER);
 
@@ -95,12 +97,12 @@ fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static st
 fn get_caller_by_frame_pointer<P>(
     ctx: &ArmContext,
     callee: &StackFrame,
-    stack_memory: &MinidumpMemory,
+    stack_memory: &MinidumpMemory<'_>,
     _modules: &MinidumpModuleList,
     _symbol_provider: &P,
 ) -> Option<StackFrame>
 where
-    P: SymbolProvider,
+    P: SymbolProvider + Sync,
 {
     trace!("unwind: trying frame pointer");
     // Assume that the standard %fp-using ARM calling convention is in use.
@@ -171,15 +173,15 @@ where
     Some(StackFrame::from_context(context, FrameTrust::FramePointer))
 }
 
-fn get_caller_by_scan<P>(
+async fn get_caller_by_scan<P>(
     ctx: &ArmContext,
     callee: &StackFrame,
-    stack_memory: &MinidumpMemory,
+    stack_memory: &MinidumpMemory<'_>,
     modules: &MinidumpModuleList,
     symbol_provider: &P,
 ) -> Option<StackFrame>
 where
-    P: SymbolProvider,
+    P: SymbolProvider + Sync,
 {
     trace!("unwind: trying scan");
     // Stack scanning is just walking from the end of the frame until we encounter
@@ -206,7 +208,7 @@ where
     for i in 0..scan_range {
         let address_of_pc = last_sp.checked_add(i * POINTER_WIDTH)?;
         let caller_pc = stack_memory.get_memory_at_address(address_of_pc as u64)?;
-        if instruction_seems_valid(caller_pc, modules, symbol_provider) {
+        if instruction_seems_valid(caller_pc, modules, symbol_provider).await {
             // pc is pushed by CALL, so sp is just address_of_pc + ptr
             let caller_sp = address_of_pc.checked_add(POINTER_WIDTH)?;
 
@@ -262,15 +264,15 @@ where
 /// would just discard the correct register values from the known frame
 /// and immediately start doing unreliable scans.
 #[allow(clippy::match_like_matches_macro)]
-fn instruction_seems_valid<P>(
+async fn instruction_seems_valid<P>(
     instruction: Pointer,
     modules: &MinidumpModuleList,
     symbol_provider: &P,
 ) -> bool
 where
-    P: SymbolProvider,
+    P: SymbolProvider + Sync,
 {
-    super::instruction_seems_valid_by_symbols(instruction as u64, modules, symbol_provider)
+    super::instruction_seems_valid_by_symbols(instruction as u64, modules, symbol_provider).await
 }
 
 /*
@@ -279,7 +281,7 @@ where
 fn stack_seems_valid(
     caller_sp: Pointer,
     callee_sp: Pointer,
-    stack_memory: &MinidumpMemory,
+    stack_memory: &MinidumpMemory<'_>,
 ) -> bool {
     // The stack shouldn't *grow* when we unwind
     if caller_sp < callee_sp {
@@ -293,65 +295,72 @@ fn stack_seems_valid(
 }
 */
 
+#[async_trait::async_trait]
 impl Unwind for ArmContext {
-    fn get_caller_frame<P>(
+    async fn get_caller_frame<P>(
         &self,
         callee: &StackFrame,
         grand_callee: Option<&StackFrame>,
-        stack_memory: Option<&MinidumpMemory>,
+        stack_memory: Option<&MinidumpMemory<'_>>,
         modules: &MinidumpModuleList,
         syms: &P,
     ) -> Option<StackFrame>
     where
-        P: SymbolProvider,
+        P: SymbolProvider + Sync,
     {
-        stack_memory
-            .as_ref()
-            .and_then(|stack| {
-                get_caller_by_cfi(self, callee, grand_callee, stack, modules, syms)
-                    .or_else(|| get_caller_by_frame_pointer(self, callee, stack, modules, syms))
-                    .or_else(|| get_caller_by_scan(self, callee, stack, modules, syms))
-            })
-            .and_then(|mut frame| {
-                // We now check the frame to see if it looks like unwinding is complete,
-                // based on the frame we computed having a nonsense value. Returning
-                // None signals to the unwinder to stop unwinding.
+        let stack = stack_memory.as_ref()?;
 
-                // if the instruction is within the first ~page of memory, it's basically
-                // null, and we can assume unwinding is complete.
-                if frame.context.get_instruction_pointer() < 4096 {
-                    trace!("unwind: instruction pointer was nullish, assuming unwind complete");
-                    return None;
-                }
-                // If the new stack pointer is at a lower address than the old,
-                // then that's clearly incorrect. Treat this as end-of-stack to
-                // enforce progress and avoid infinite loops.
-                let sp = frame.context.get_stack_pointer();
-                let last_sp = self.get_register_always("sp") as u64;
-                if sp <= last_sp {
-                    // Arm leaf functions may not actually touch the stack (thanks
-                    // to the link register allowing you to "push" the return address
-                    // to a register), so we need to permit the stack pointer to not
-                    // change for the first frame of the unwind. After that we need
-                    // more strict validation to avoid infinite loops.
-                    let is_leaf = callee.trust == FrameTrust::Context && sp == last_sp;
-                    if !is_leaf {
-                        trace!("unwind: stack pointer went backwards, assuming unwind complete");
-                        return None;
-                    }
-                }
+        // .await doesn't like closures, so don't use Option chaining
+        let mut frame = None;
+        if frame.is_none() {
+            frame = get_caller_by_cfi(self, callee, grand_callee, stack, modules, syms).await;
+        }
+        if frame.is_none() {
+            frame = get_caller_by_frame_pointer(self, callee, stack, modules, syms);
+        }
+        if frame.is_none() {
+            frame = get_caller_by_scan(self, callee, stack, modules, syms).await;
+        }
+        let mut frame = frame?;
 
-                // Ok, the frame now seems well and truly valid, do final cleanup.
+        // We now check the frame to see if it looks like unwinding is complete,
+        // based on the frame we computed having a nonsense value. Returning
+        // None signals to the unwinder to stop unwinding.
 
-                // A caller's ip is the return address, which is the instruction
-                // *after* the CALL that caused us to arrive at the callee. Set
-                // the value to 2 less than that, so it points to the CALL instruction
-                // (arm instructions are all 2 bytes wide). This is important because
-                // we use this value to lookup the CFI we need to unwind the next frame.
-                let ip = frame.context.get_instruction_pointer() as u64;
-                frame.instruction = ip - 2;
+        // if the instruction is within the first ~page of memory, it's basically
+        // null, and we can assume unwinding is complete.
+        if frame.context.get_instruction_pointer() < 4096 {
+            trace!("unwind: instruction pointer was nullish, assuming unwind complete");
+            return None;
+        }
+        // If the new stack pointer is at a lower address than the old,
+        // then that's clearly incorrect. Treat this as end-of-stack to
+        // enforce progress and avoid infinite loops.
+        let sp = frame.context.get_stack_pointer();
+        let last_sp = self.get_register_always("sp") as u64;
+        if sp <= last_sp {
+            // Arm leaf functions may not actually touch the stack (thanks
+            // to the link register allowing you to "push" the return address
+            // to a register), so we need to permit the stack pointer to not
+            // change for the first frame of the unwind. After that we need
+            // more strict validation to avoid infinite loops.
+            let is_leaf = callee.trust == FrameTrust::Context && sp == last_sp;
+            if !is_leaf {
+                trace!("unwind: stack pointer went backwards, assuming unwind complete");
+                return None;
+            }
+        }
 
-                Some(frame)
-            })
+        // Ok, the frame now seems well and truly valid, do final cleanup.
+
+        // A caller's ip is the return address, which is the instruction
+        // *after* the CALL that caused us to arrive at the callee. Set
+        // the value to 2 less than that, so it points to the CALL instruction
+        // (arm instructions are all 2 bytes wide). This is important because
+        // we use this value to lookup the CFI we need to unwind the next frame.
+        let ip = frame.context.get_instruction_pointer() as u64;
+        frame.instruction = ip - 2;
+
+        Some(frame)
     }
 }

--- a/minidump-processor/src/stackwalker/unwind.rs
+++ b/minidump-processor/src/stackwalker/unwind.rs
@@ -6,16 +6,17 @@ use crate::SymbolProvider;
 use minidump::{MinidumpMemory, MinidumpModuleList};
 
 /// A trait for things that can unwind to a caller.
+#[async_trait::async_trait]
 pub trait Unwind {
     /// Get the caller frame of this frame.
-    fn get_caller_frame<P>(
+    async fn get_caller_frame<P>(
         &self,
         callee: &StackFrame,
         grand_callee: Option<&StackFrame>,
-        stack_memory: Option<&MinidumpMemory>,
+        stack_memory: Option<&MinidumpMemory<'_>>,
         modules: &MinidumpModuleList,
         symbol_provider: &P,
     ) -> Option<StackFrame>
     where
-        P: SymbolProvider;
+        P: SymbolProvider + Sync;
 }

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4"
 minidump = { version = "0.9.6", path = "../minidump" }
 minidump-processor = { version = "0.9.6", path = "../minidump-processor" }
 simplelog = "0.11.2"
+tokio =  { version = "1.12.0", features = ["full"] }
 
 [features]
 vendored-openssl = ["openssl/vendored"]

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -221,7 +221,8 @@ native debuginfo formats. We recommend using a version of dump_syms to generate 
 }
 
 #[cfg_attr(test, allow(dead_code))]
-fn main() {
+#[tokio::main]
+async fn main() {
     let matches = make_app().get_matches();
 
     // This is a little hack to generate a markdown version of the --help message,
@@ -388,7 +389,8 @@ fn main() {
                 ))));
             }
 
-            match minidump_processor::process_minidump_with_options(&dump, &provider, options) {
+            match minidump_processor::process_minidump_with_options(&dump, &provider, options).await
+            {
                 Ok(state) => {
                     let mut stdout;
                     let mut output_f;


### PR DESCRIPTION
I was curious how bad this was and then suddenly I was "done" lol

This compiles and correctly handles amd64.

TODO: 

* [x] copy-paste changes to other stackwalking backends (and re-enable them)
* [x] make tests work with async (with `#[tokio::test]`?)
* [x] make sure the symbolic-syms shim still compiles
* [x] performance analysis (socc-pair --bench)
* ~~[ ] test `#[tokio::main(flavor = "current_thread")]`~~ (perf analysis came back good enough that I don't care)
