### PR TITLE
Make --human the default output of minidump-stackwalk 

### DIFF
--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
         .arg(
             Arg::with_name("json")
                 .long("json")
-                .long_help("Emit a machine-readable JSON report (the default).
+                .long_help("Emit a machine-readable JSON report.
 
 The schema for this output is officially documented here:
 https://github.com/luser/rust-minidump/blob/master/minidump-processor/json-schema.md\n\n\n")
@@ -42,10 +42,10 @@ https://github.com/luser/rust-minidump/blob/master/minidump-processor/json-schem
         .arg(
             Arg::with_name("human")
                 .long("human")
-                .long_help("Emit a human-readable report.
+                .long_help("Emit a human-readable report (the default).
 
 The human-readable report does not have a specified format, and may not have as \
-many details as the default JSON format. It is intended for quickly inspecting \
+many details as the JSON format. It is intended for quickly inspecting \
 a crash or debugging rust-minidump itself.\n\n\n")
         )
         .arg(
@@ -320,11 +320,11 @@ native debuginfo formats. We recommend using a version of dump_syms to generate 
     let minidump_path = matches.value_of_os("minidump").map(Path::new).unwrap();
 
     // Determine the kind of output we're producing -- json, human, or cyborg (both).
-    // Although we have a --json argument it's mostly just there to make the documentation
-    // more clear. json output is enabled by default, and --human disables it.
+    // Although we have a --human argument it's mostly just there to make the documentation
+    // more clear. human output is enabled by default, and --json disables it.
     // Mutual exclusion is enforced by an ArgGroup.
-    let mut human = matches.is_present("human");
-    let mut json = !human;
+    let mut json = matches.is_present("json");
+    let mut human = !json;
     let cyborg = matches.value_of_os("cyborg").map(Path::new);
 
     if cyborg.is_some() {


### PR DESCRIPTION
There are 3 different binaries which call themselves minidump-stackwalk

1. breakpad's minidump-stackwalk (human output)
2. mozilla's minidump-stackwalk (json output)
3. rust-minidump's minidump-stackwalk (both)

This implementation (mdsw 3) was primarily designed to replace mdsw 2, so
default to json output was "natural". However mdsw 1 is actually run locally
and in the wild more, so emulating their interface is probably the
better default, even if the json output is the "first-class" output.

This will be part of the 0.9.6 release, and is a fairly major breaking change,
but also fairly trivial to handle downstream -- just pass the --json flag.

Note that minidump-stackwalk 0.9.5 introduced --json even while it was the
default, so you can more easily handle this transition by always specifying
--json or --human instead of relying on the default.

fixes #337