### PR TITLE
Use reqwest's Bytes type instead of copying into a Vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "breakpad-symbols"
 version = "0.9.6"
 dependencies = [
+ "bytes",
  "failure",
  "log",
  "minidump-common",

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 travis-ci = { repository = "luser/rust-minidump" }
 
 [dependencies]
+bytes = "1.1.0"
 minidump-common = { version = "0.9.6", path = "../minidump-common" }
 range-map = "0.1.5"
 nom = "~1.2.2"

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -29,6 +29,7 @@
 //!               "vswprintf");
 //! ```
 
+use bytes::Bytes;
 use failure::Error;
 use log::{debug, trace, warn};
 use reqwest::blocking::Client;
@@ -40,7 +41,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -419,12 +420,11 @@ fn fetch_symbol_file(
     rel_path: &str,
     cache: &Path,
     tmp: &Path,
-) -> Result<(Url, Vec<u8>), Error> {
+) -> Result<(Url, Bytes), Error> {
     let url = base_url.join(rel_path)?;
     debug!("Trying {}", url);
-    let mut res = client.get(url.clone()).send()?.error_for_status()?;
-    let mut buf = vec![];
-    res.read_to_end(&mut buf)?;
+    let res = client.get(url.clone()).send()?.error_for_status()?;
+    let buf = res.bytes()?;
     let local = cache.join(rel_path);
 
     match save_contents(&buf, &url, &local, tmp) {


### PR DESCRIPTION
50% chance this elides an enormous copy and a bunch of reallocations, but no idea.
The async branch needs this anyway so no harm to do it now.