### PR TITLE
Streaming Symbol Parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "breakpad-symbols"
 version = "0.9.6"
 dependencies = [
- "bytes",
+ "circular",
  "failure",
  "log",
  "minidump-common",
@@ -141,6 +141,12 @@ dependencies = [
  "time",
  "winapi",
 ]
+
+[[package]]
+name = "circular"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fc239e0f6cb375d2402d48afb92f76f5404fd1df208a41930ec81eda078bea"
 
 [[package]]
 name = "clap"

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 travis-ci = { repository = "luser/rust-minidump" }
 
 [dependencies]
-bytes = "1.1.0"
+circular = "0.3.0"
 minidump-common = { version = "0.9.6", path = "../minidump-common" }
 range-map = "0.1.5"
 nom = "~1.2.2"


### PR DESCRIPTION
This changes the breakpad-symbols parser to stream its input. This allows us to:

* Avoid ever manifesting the entire (~GB) symbol file in memory
* Parse as the file downloads
* Save to the cache as the file downloads
* Theoretically eliminate a ton of (re)allocations and copies

See breakpad_symbols/src/syms/mod.rs : SymbolFile::parse for discussion of the design