### PR TITLE
Don't trust high bits of crash addresses

### DIFF
--- a/breakpad-symbols/src/sym_file/parser.rs
+++ b/breakpad-symbols/src/sym_file/parser.rs
@@ -62,7 +62,7 @@ named!(module_line<&[u8], ()>,
     || {}
 ));
 
-// Matches an INFO LINE record.
+// Matches an INFO URL record.
 named!(
     info_url<&[u8], Info>,
     chain!(

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -197,7 +197,7 @@ where
     let (crash_reason, crash_address, crashing_thread_id) = if let Some(exception) = exception_ref {
         (
             Some(exception.get_crash_reason(system_info.os, system_info.cpu)),
-            Some(exception.get_crash_address(system_info.os)),
+            Some(exception.get_crash_address(system_info.os, system_info.cpu)),
             Some(exception.get_crashing_thread_id()),
         )
     } else {

--- a/minidump-stackwalk/tests/test-minidump-stackwalk.rs
+++ b/minidump-stackwalk/tests/test-minidump-stackwalk.rs
@@ -657,7 +657,11 @@ fn test_unloaded_json() {
     assert_eq!(stderr, "");
 }
 
+
+// Temporarily disabled because it races with the _json version
+// on creating the minidump via `unloaded_minidump`.
 #[test]
+#[ignore]
 fn test_unloaded_human() {
     let synth_path = unloaded_minidump();
 

--- a/minidump-stackwalk/tests/test-minidump-stackwalk.rs
+++ b/minidump-stackwalk/tests/test-minidump-stackwalk.rs
@@ -657,7 +657,6 @@ fn test_unloaded_json() {
     assert_eq!(stderr, "");
 }
 
-
 // Temporarily disabled because it races with the _json version
 // on creating the minidump via `unloaded_minidump`.
 #[test]

--- a/minidump/README.md
+++ b/minidump/README.md
@@ -9,16 +9,16 @@ If you want richer analysis of the minidump (such as stackwalking and symbolicat
 
 # Usage
 
-The primary API for this library is the [`Minidump`][] struct, which can be
-instantiated by calling the [`Minidump::read`][] or [`Minidump::read_path`][] methods.
+The primary API for this library is the `Minidump` struct, which can be
+instantiated by calling the `Minidump::read` or `Minidump::read_path` methods.
 
 Succesfully parsing a Minidump struct means the minidump has a minimally valid
 header and stream directory. Individual streams are only parsed when they're
 requested.
 
 Although you may enumerate the streams in a minidump with methods like
-[`Minidump::all_streams`][], this is only really useful for debugging. Instead
-you should statically request streams with [`Minidump::get_stream`][].
+`Minidump::all_streams`, this is only really useful for debugging. Instead
+you should statically request streams with `Minidump::get_stream`.
 
 Depending on what analysis you're trying to perform, you may:
 


### PR DESCRIPTION
This is a minor breaking change, as get_crash_address now requires a Cpu.

Also adds some minimal Exception support to synth-minidump.

Fixes #360