### PR TITLE
ref: Replace deprecated crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,6 @@ dependencies = [
  "nom",
  "range-map",
  "reqwest",
- "tempdir",
  "tempfile",
 ]
 
@@ -137,8 +136,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.14",
- "serde",
- "time",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -377,12 +375,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures-channel"
@@ -656,13 +648,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "fe3179b85e1fd8b14447cbebadb75e45a1002f541b925f0bfec366d56a81c56d"
 dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]
@@ -675,18 +666,18 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 name = "minidump"
 version = "0.9.6"
 dependencies = [
- "chrono",
  "doc-comment",
  "encoding",
  "failure",
  "log",
- "memmap",
+ "memmap2",
  "minidump-common",
  "num-traits 0.2.14",
  "range-map",
  "scroll",
  "synth-minidump",
  "test-assembler",
+ "time 0.3.7",
 ]
 
 [[package]]
@@ -707,17 +698,15 @@ name = "minidump-processor"
 version = "0.9.6"
 dependencies = [
  "breakpad-symbols",
- "chrono",
  "clap",
  "doc-comment",
  "failure",
  "log",
- "memmap",
+ "memmap2",
  "minidump",
  "scroll",
  "serde",
  "serde_json",
- "simplelog",
  "synth-minidump",
  "test-assembler",
 ]
@@ -841,6 +830,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,49 +939,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
 name = "range-map"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87dc8ff3b0f3e32dbba6e49c592c0191a3a2cabbf6f7e5a78e1010050b9a42e1"
 dependencies = [
  "num-traits 0.1.43",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1245,16 +1206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1275,17 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -22,6 +22,3 @@ log = "0.4.1"
 reqwest = { version = "0.11.6", features = ["blocking", "gzip"] }
 failure = "0.1.1"
 tempfile = "3.3.0"
-
-[dev-dependencies]
-tempdir = "0.3"

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -787,7 +787,6 @@ mod test {
     use std::fs::File;
     use std::io::Write;
     use std::path::{Path, PathBuf};
-    use tempdir::TempDir;
 
     #[test]
     fn test_relative_symbol_path() {
@@ -887,7 +886,7 @@ mod test {
 
     #[test]
     fn test_simple_symbol_supplier() {
-        let t = TempDir::new("symtest").unwrap();
+        let t = tempfile::tempdir().unwrap();
         let paths = mksubdirs(t.path(), &["one", "two"]);
 
         let supplier = SimpleSymbolSupplier::new(paths.clone());
@@ -929,7 +928,7 @@ mod test {
 
     #[test]
     fn test_symbolizer() {
-        let t = TempDir::new("symtest").unwrap();
+        let t = tempfile::tempdir().unwrap();
         let path = t.path();
 
         // TODO: This could really use a MockSupplier

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -21,15 +21,13 @@ symbolic-syms = []
 
 [dependencies]
 breakpad-symbols = { version = "0.9.6", path = "../breakpad-symbols", optional = true }
-chrono = { version = "0.4.6", features = ["serde"] }
 clap = "2.34"
 failure = "0.1.1"
 log = "0.4"
-memmap = "0.7.0"
+memmap2 = "0.5.2"
 minidump = { version = "0.9.6", path = "../minidump" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-simplelog = "0.11.2"
 scroll = "0.10.2"
 
 [dev-dependencies]

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -7,10 +7,10 @@ use std::borrow::{Borrow, Cow};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io;
 use std::io::prelude::*;
+use std::time::SystemTime;
 
 use crate::system_info::SystemInfo;
 use crate::{FrameSymbolizer, SymbolStats};
-use chrono::prelude::*;
 use minidump::system_info::Cpu;
 use minidump::*;
 use serde_json::json;
@@ -150,9 +150,9 @@ pub struct ProcessState {
     /// The PID of the process.
     pub process_id: Option<u32>,
     /// When the minidump was written.
-    pub time: DateTime<Utc>,
+    pub time: SystemTime,
     /// When the process started, if available
-    pub process_create_time: Option<DateTime<Utc>>,
+    pub process_create_time: Option<SystemTime>,
     /// Known code signing certificates (module name => cert name)
     pub cert_info: HashMap<String, String>,
     /// If the process crashed, a `CrashReason` describing the crash reason.
@@ -507,8 +507,8 @@ Crash address: {:#x}
             writeln!(f)?;
         }
         if let Some(ref time) = self.process_create_time {
-            let uptime = self.time - *time;
-            writeln!(f, "Process uptime: {} seconds", uptime.num_seconds())?;
+            let uptime = self.time.duration_since(*time).unwrap_or_default();
+            writeln!(f, "Process uptime: {} seconds", uptime.as_secs())?;
         } else {
             writeln!(f, "Process uptime: not available")?;
         }

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -1,12 +1,12 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use chrono::{TimeZone, Utc};
 use failure::Fail;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;
 use std::path::Path;
+use std::time::{Duration, SystemTime};
 
 use minidump::{self, *};
 
@@ -297,7 +297,7 @@ where
 
     Ok(ProcessState {
         process_id,
-        time: Utc.timestamp(dump.header.time_date_stamp as i64, 0),
+        time: SystemTime::UNIX_EPOCH + Duration::from_secs(dump.header.time_date_stamp as u64),
         process_create_time,
         cert_info: evil.certs,
         crash_reason,

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -32,7 +32,7 @@ fn locate_testdata() -> PathBuf {
     panic!("Couldn't find testdata directory! Tried: {:?}", paths);
 }
 
-fn read_test_minidump() -> Result<Minidump<'static, memmap::Mmap>, Error> {
+fn read_test_minidump() -> Result<Minidump<'static, memmap2::Mmap>, Error> {
     let path = locate_testdata().join("test.dmp");
     println!("minidump: {:?}", path);
     Minidump::read_path(&path)

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -18,9 +18,9 @@ log = "0.4.1"
 minidump-common = { version = "0.9.6", path = "../minidump-common" }
 num-traits = "0.2"
 encoding = "0.2"
-chrono = "0.4.6"
 scroll = "0.10.2"
-memmap = "0.7.0"
+memmap2 = "0.5.2"
+time = { version = "0.3.6", features = ["formatting"] }
 
 [dev-dependencies]
 synth-minidump = { path = "../synth-minidump" }

--- a/minidump/tests/test_minidump.rs
+++ b/minidump/tests/test_minidump.rs
@@ -1,8 +1,7 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use chrono::prelude::*;
-use memmap::Mmap;
+use memmap2::Mmap;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
 use minidump_common::format as md;
@@ -11,6 +10,7 @@ use num_traits::cast::FromPrimitive;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 fn get_test_minidump_path(filename: &str) -> PathBuf {
     let mut path = PathBuf::from(file!());
@@ -138,8 +138,13 @@ fn test_misc_info() {
     assert_eq!(misc_info.raw.process_id(), Some(&3932));
     assert_eq!(misc_info.raw.process_create_time(), Some(&0x45d35f73));
     assert_eq!(
-        misc_info.process_create_time().unwrap(),
-        Utc.ymd(2007, 2, 14).and_hms(19, 13, 55)
+        misc_info
+            .process_create_time()
+            .unwrap()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        1171480435, // = 2007-02-14T19:13:55
     );
 }
 


### PR DESCRIPTION
- Removes `tempdir` in favor of `tempfile`.
- Replaces `mmap` by `mmap2`.
- Replaces `chrono` by `SystemTime`/`time`.

All these crates have rustsec advisories, mostly because they are deprecated or unmaintained.

`chrono` is still being pulled in by `simplelog` though :-(

This is technically a breaking change, because both `mmap` and `chrono` were part of the public API.