### PR TITLE
Implement register iterators for all context types

### DIFF
--- a/minidump-processor/src/stackwalker/arm.rs
+++ b/minidump-processor/src/stackwalker/arm.rs
@@ -24,7 +24,7 @@ const FRAME_POINTER: &str = Registers::FramePointer.name();
 const STACK_POINTER: &str = Registers::StackPointer.name();
 const PROGRAM_COUNTER: &str = Registers::ProgramCounter.name();
 const LINK_REGISTER: &str = Registers::LinkRegister.name();
-const CALLEE_SAVED_REGS: &[&str] = &["r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11"];
+const CALLEE_SAVED_REGS: &[&str] = &["r4", "r5", "r6", "r7", "r8", "r9", "r10", "fp"];
 
 fn get_caller_by_cfi<P>(
     ctx: &ArmContext,

--- a/minidump-processor/src/stackwalker/arm64.rs
+++ b/minidump-processor/src/stackwalker/arm64.rs
@@ -25,7 +25,7 @@ const STACK_POINTER: &str = Registers::StackPointer.name();
 const LINK_REGISTER: &str = Registers::LinkRegister.name();
 const PROGRAM_COUNTER: &str = Registers::ProgramCounter.name();
 const CALLEE_SAVED_REGS: &[&str] = &[
-    "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28", "x29",
+    "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28", "fp",
 ];
 
 fn get_caller_by_cfi<P>(

--- a/minidump-processor/src/stackwalker/arm64_old.rs
+++ b/minidump-processor/src/stackwalker/arm64_old.rs
@@ -25,7 +25,7 @@ const STACK_POINTER: &str = Registers::StackPointer.name();
 const LINK_REGISTER: &str = Registers::LinkRegister.name();
 const PROGRAM_COUNTER: &str = Registers::ProgramCounter.name();
 const CALLEE_SAVED_REGS: &[&str] = &[
-    "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28", "x29",
+    "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28", "fp",
 ];
 
 fn get_caller_by_cfi<P>(

--- a/minidump-processor/src/stackwalker/arm_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm_unittest.rs
@@ -426,7 +426,7 @@ fn test_frame_pointer_infinite_equality() {
     // Never get to frame 2, alas!
 }
 
-const CALLEE_SAVE_REGS: &[&str] = &["pc", "sp", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11"];
+const CALLEE_SAVE_REGS: &[&str] = &["pc", "sp", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "fp"];
 
 fn init_cfi_state() -> (TestFixture, Section, CONTEXT_ARM, MinidumpContextValidity) {
     let mut f = TestFixture::new();

--- a/minidump/src/context.rs
+++ b/minidump/src/context.rs
@@ -1289,7 +1289,7 @@ impl MinidumpContext {
     }
 
     pub fn valid_registers(&self) -> impl Iterator<Item = (&'static str, u64)> + '_ {
-        // This is suboptimal in theorey, as we could iterate over self.valid just like the original
+        // This is suboptimal in theory, as we could iterate over self.valid just like the original
         // and faster `CpuRegisters` iterator does. However, this complicates code here, and the
         // minimal gain in performance hasn't been worth the added complexity.
         self.registers().filter(move |(reg, _)| match &self.raw {


### PR DESCRIPTION
Adds a `registers` and `valid_registers` iterator to all context types, as well as the general `MinidumpContext` type. This makes it possible to enumerate registers in a generic way without special-casing the concrete context types on usage site. The register name constants are moved to an associated constant in the trait.