### PR TITLE
Expose original return address in ProcessState

### DIFF
--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -64,7 +64,9 @@ pub struct StackFrame {
     /// The address from which the program counter would resume.
     ///
     /// This is the address which contains the next instruction to be executed in the
-    /// caller, once the callee has completed.
+    /// caller, once the callee has completed.  This is sometimes called the
+    /// `return_address`, e.g. in breakpad, as it is where the callee will return to once
+    /// finished, so this is really the *callee's return address*.
     ///
     /// For the address from which the caller called the callee, see
     /// [`StackFrame::instruction`].

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -63,7 +63,7 @@ pub struct StackFrame {
     pub instruction: u64,
 
     /// Return the actual return address, as saved on the stack or in a
-    /// register. See the comments for `instruction`, below, for details.
+    /// register. See the comments for `instruction`, for details.
     pub return_address: u64,
 
     /// The module in which the instruction resides.
@@ -237,6 +237,7 @@ impl StackFrame {
     pub fn from_context(context: MinidumpContext, trust: FrameTrust) -> StackFrame {
         StackFrame {
             instruction: context.get_instruction_pointer(),
+            // Initialized the same as `instruction`, but left unmodified during stack walking.
             return_address: context.get_instruction_pointer(),
             module: None,
             unloaded_modules: BTreeMap::new(),
@@ -249,12 +250,6 @@ impl StackFrame {
             trust,
             context,
         }
-    }
-
-    /// Return the actual return address, as saved on the stack or in a
-    /// register. See the comments for `StackFrame::instruction` for details.
-    pub fn return_address(&self) -> u64 {
-        self.instruction
     }
 }
 

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -61,21 +61,21 @@ pub struct StackFrame {
     /// requires adjustment.
     pub instruction: u64,
 
-   /// The instruction address (program counter) that execution of this function
+    /// The instruction address (program counter) that execution of this function
     /// would resume at, if the callee returns.
     ///
     /// This is exactly **the return address of the of the callee**. We use this
     /// nonstandard terminology because just calling this "return address"
     /// would be ambiguous and too easy to mix up.
     ///
-    /// **Note:** you should strongly prefer using [`instruction`][], which should
+    /// **Note:** you should strongly prefer using [`StackFrame::instruction`][], which should
     /// be the address of the instruction before this one which called the callee.
     /// That is the instruction that this function was logically "executing" when the
     /// program's state was captured, and therefore what people expect from
     /// backtraces.
     ///
     /// This is more than a matter of user expections: **there are situations
-    /// where this value is nonsensical but the [`instruction`][] is valid.**
+    /// where this value is nonsensical but the [`StackFrame::instruction`][] is valid.**
     ///
     /// Specifically, if the callee is "noreturn" then *this function should
     /// never resume execution*. The compiler has no obligation to emit any
@@ -86,7 +86,7 @@ pub struct StackFrame {
     /// Yes, compilers *can* just immediately jump into the callee for
     /// noreturn calls, but it's genuinely very helpful for them to emit a
     /// CALL because it keeps the stack reasonable for backtraces and
-    /// debuggers, which are more interested in [`instruction`][] anyway!
+    /// debuggers, which are more interested in [`StackFrame::instruction`][] anyway!
     ///
     /// (If this is the top frame of the call stack, then `resume_address`
     /// and `instruction` are exactly equal and should reflect the actual

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -58,9 +58,13 @@ pub struct StackFrame {
     ///
     /// On some architectures, the return address as saved on the stack or in
     /// a register is fine for looking up the point of the call. On others, it
-    /// requires adjustment. ReturnAddress returns the address as saved by the
+    /// requires adjustment. `return_address` returns the address as saved by the
     /// machine.
     pub instruction: u64,
+
+    /// Return the actual return address, as saved on the stack or in a
+    /// register. See the comments for `instruction`, below, for details.
+    pub return_address: u64,
 
     /// The module in which the instruction resides.
     pub module: Option<MinidumpModule>,
@@ -233,6 +237,7 @@ impl StackFrame {
     pub fn from_context(context: MinidumpContext, trust: FrameTrust) -> StackFrame {
         StackFrame {
             instruction: context.get_instruction_pointer(),
+            return_address: context.get_instruction_pointer(),
             module: None,
             unloaded_modules: BTreeMap::new(),
             function_name: None,

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -58,13 +58,17 @@ pub struct StackFrame {
     ///
     /// On some architectures, the return address as saved on the stack or in
     /// a register is fine for looking up the point of the call. On others, it
-    /// requires adjustment. `return_address` returns the address as saved by the
-    /// machine.
+    /// requires adjustment.
     pub instruction: u64,
 
-    /// Return the actual return address, as saved on the stack or in a
-    /// register. See the comments for `instruction`, for details.
-    pub return_address: u64,
+    /// The address from which the program counter would resume.
+    ///
+    /// This is the address which contains the next instruction to be executed in the
+    /// caller, once the callee has completed.
+    ///
+    /// For the address from which the caller called the callee, see
+    /// [`StackFrame::instruction`].
+    pub resume_address: u64,
 
     /// The module in which the instruction resides.
     pub module: Option<MinidumpModule>,
@@ -238,7 +242,7 @@ impl StackFrame {
         StackFrame {
             instruction: context.get_instruction_pointer(),
             // Initialized the same as `instruction`, but left unmodified during stack walking.
-            return_address: context.get_instruction_pointer(),
+            resume_address: context.get_instruction_pointer(),
             module: None,
             unloaded_modules: BTreeMap::new(),
             function_name: None,

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -87,7 +87,7 @@ async fn test_traditional() {
         .append_repeated(12, 0) // frame 0: space
         .mark(&frame0_ebp) // frame 0 %ebp points here
         .D32(&frame1_ebp) // frame 0: saved %ebp
-        .D32(0x40008679) // frame 0: return address
+        .D32(0x40008679) // frame 0: resume address
         .append_repeated(8, 0) // frame 1: space
         .mark(&frame1_ebp) // frame 1 %ebp points here
         .D32(0) // frame 1: saved %ebp (stack end)
@@ -102,6 +102,7 @@ async fn test_traditional() {
         assert_eq!(f0.trust, FrameTrust::Context);
         assert_eq!(f0.context.valid, MinidumpContextValidity::All);
         assert_eq!(f0.instruction, 0x4000c7a5);
+        assert_eq!(f0.resume_address, 0x4000c7a5);
         // eip
         // ebp
     }
@@ -110,6 +111,7 @@ async fn test_traditional() {
         assert_eq!(f1.trust, FrameTrust::FramePointer);
         // ContextValidity
         assert_eq!(f1.instruction, 0x40008678);
+        assert_eq!(f1.resume_address, 0x40008679);
         // eip
         // ebp
     }
@@ -154,6 +156,7 @@ async fn test_traditional_scan() {
         assert_eq!(f0.trust, FrameTrust::Context);
         assert_eq!(f0.context.valid, MinidumpContextValidity::All);
         assert_eq!(f0.instruction, 0x4000f49d);
+        assert_eq!(f0.resume_address, 0x4000f49d);
 
         if let MinidumpRawContext::X86(ctx) = &f0.context.raw {
             assert_eq!(ctx.eip, 0x4000f49d);
@@ -176,6 +179,7 @@ async fn test_traditional_scan() {
             unreachable!();
         }
         assert_eq!(f1.instruction + 1, 0x4000129d);
+        assert_eq!(f1.resume_address, 0x4000129d);
 
         if let MinidumpRawContext::X86(ctx) = &f1.context.raw {
             assert_eq!(ctx.eip, 0x4000129d);


### PR DESCRIPTION
The `instruction_address` field already has heuristics applied, mostly
substracting the size of an instruction, to point to the caller rather than the
return address. Breakpad additionally exposed the unmodified `return_address`
which can be useful at times.

Since `instruction_address` starts with the return address and then modifies it
during stack walking, the only change needed is to retain an unmodified copy.

