### PR TITLE
Add thread_id to CallStacks in the ProcessState

### DIFF
--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -131,6 +131,8 @@ pub struct CallStack {
     pub frames: Vec<StackFrame>,
     /// Information about this `CallStack`.
     pub info: CallStackInfo,
+    /// The identifier of the thread.
+    pub thread_id: u32,
     /// The name of the thread, if known.
     pub thread_name: Option<String>,
     /// The GetLastError() value stored in the TEB.
@@ -326,10 +328,11 @@ fn json_registers(ctx: &MinidumpContext) -> serde_json::Value {
 
 impl CallStack {
     /// Create a `CallStack` with `info` and no frames.
-    pub fn with_info(info: CallStackInfo) -> CallStack {
+    pub fn with_info(id: u32, info: CallStackInfo) -> CallStack {
         CallStack {
             info,
             frames: vec![],
+            thread_id: id,
             thread_name: None,
             last_error_value: None,
         }

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -223,9 +223,11 @@ where
     let mut threads = vec![];
     let mut requesting_thread = None;
     for (i, thread) in thread_list.threads.iter().enumerate() {
+        let id = thread.raw.thread_id;
+
         // If this is the thread that wrote the dump, skip processing it.
-        if dump_thread_id.is_some() && dump_thread_id.unwrap() == thread.raw.thread_id {
-            threads.push(CallStack::with_info(CallStackInfo::DumpThreadSkipped));
+        if dump_thread_id.is_some() && dump_thread_id.unwrap() == id {
+            threads.push(CallStack::with_info(id, CallStackInfo::DumpThreadSkipped));
             continue;
         }
 
@@ -250,6 +252,7 @@ where
 
         let mut stack =
             stackwalker::walk_stack(&context, stack.as_deref(), &modules, symbol_provider);
+        stack.thread_id = id;
 
         for frame in &mut stack.frames {
             // If the frame doesn't have a loaded module, try to find an unloaded module

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -198,6 +198,7 @@ where
     CallStack {
         frames,
         info,
+        thread_id: 0,
         thread_name: None,
         last_error_value: None,
     }


### PR DESCRIPTION
The `thread_id` is part of the raw minidump thread structure, but not the processed `CallStack`. This is an inconvenience when dealing with the process state.

If preferred, we could also add the raw thread structure as field to `CallStack`. 