### PR TITLE
Process OS build into a dedicated field

### DIFF
--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -434,7 +434,7 @@ impl ProcessState {
 
     fn print_internal<T: Write>(&self, f: &mut T, brief: bool) -> io::Result<()> {
         writeln!(f, "Operating system: {}", self.system_info.os.long_name())?;
-        if let Some(ref ver) = self.system_info.os_version {
+        if let Some(ref ver) = self.system_info.format_os_version() {
             writeln!(f, "                  {}", ver)?;
         }
         writeln!(f, "CPU: {}", self.system_info.cpu)?;
@@ -654,7 +654,7 @@ Unknown streams encountered:
             "system_info": {
                 // Linux | Windows NT | Mac OS X
                 "os": sys.os.long_name(),
-                "os_ver": sys.os_version,
+                "os_ver": sys.format_os_version(),
                 // x86 | amd64 | arm | ppc | sparc
                 "cpu_arch": sys.cpu.to_string(),
                 "cpu_info": sys.cpu_info,

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -92,16 +92,17 @@ where
         .get_stream::<MinidumpSystemInfo>()
         .or(Err(ProcessError::MissingSystemInfo))?;
 
-    let mut os_version = format!(
+    let os_version = format!(
         "{}.{}.{}",
         dump_system_info.raw.major_version,
         dump_system_info.raw.minor_version,
         dump_system_info.raw.build_number
     );
-    if let Some(csd_version) = dump_system_info.csd_version() {
-        os_version.push(' ');
-        os_version.push_str(&csd_version);
-    }
+
+    let os_build = dump_system_info
+        .csd_version()
+        .map(|v| v.trim().to_owned())
+        .filter(|v| !v.is_empty());
 
     let linux_standard_base = dump.get_stream::<MinidumpLinuxLsbRelease>().ok();
     let linux_cpu_info = dump
@@ -155,6 +156,7 @@ where
     let system_info = SystemInfo {
         os: dump_system_info.os,
         os_version: Some(os_version),
+        os_build,
         cpu: dump_system_info.cpu,
         cpu_info,
         cpu_microcode_version,

--- a/minidump-processor/src/system_info.rs
+++ b/minidump-processor/src/system_info.rs
@@ -4,10 +4,15 @@ use minidump::system_info::{Cpu, Os};
 pub struct SystemInfo {
     /// The operating system that produced the minidump
     pub os: Os,
-    /// A string identifying the version of the operating system
+    /// A string identifying the version of the operating system.
     ///
-    /// This may look like "5.1.2600 Service Pack 2" or "10.4.8 8L2127", if present
+    /// This may look like "5.1.2600" or "10.4.8", if present
     pub os_version: Option<String>,
+    /// A string identifying the exact build of the operating system.
+    ///
+    /// This may look like "Service Pack 2" or "8L2127", if present. On Windows, this is the CSD
+    /// version, on Linux extended build information.
+    pub os_build: Option<String>,
     /// The CPU on which the dump was produced
     pub cpu: Cpu,
     /// A string further identifying the specific CPU

--- a/minidump-processor/src/system_info.rs
+++ b/minidump-processor/src/system_info.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use minidump::system_info::{Cpu, Os};
 
 /// Information about the system that produced a `Minidump`.
@@ -25,4 +27,18 @@ pub struct SystemInfo {
     ///
     /// Will be greater than one for multi-core systems.
     pub cpu_count: usize,
+}
+
+impl SystemInfo {
+    /// Returns the full available operating system version.
+    ///
+    /// Returns the version and the build, if available, otherwise just the version.
+    pub fn format_os_version(&self) -> Option<Cow<'_, str>> {
+        match (&self.os_version, &self.os_build) {
+            (Some(v), Some(b)) => Some(format!("{} {}", v, b).into()),
+            (Some(v), None) => Some(Cow::Borrowed(v)),
+            (None, Some(b)) => Some(Cow::Borrowed(b)),
+            (None, None) => None,
+        }
+    }
 }

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -53,9 +53,8 @@ fn test_processor() {
     )
     .unwrap();
     assert_eq!(state.system_info.os, Os::Windows);
-    // TODO
-    // assert_eq!(state.system_info.os_version.unwrap(),
-    // "5.1.2600 Service Pack 2");
+    assert_eq!(state.system_info.os_version.unwrap(), "5.1.2600");
+    assert_eq!(state.system_info.os_build.unwrap(), "Service Pack 2");
     assert_eq!(state.system_info.cpu, Cpu::X86);
     // TODO:
     // assert_eq!(state.system_info.cpu_info.unwrap(),


### PR DESCRIPTION
The processor joins the operating system version and build into a single field.
While this is a common way to represent the version, it is convenient to have
them separate.


