### PR TITLE
Harden 32-bit unwinders against mixed-width calculations.

### DIFF
--- a/minidump-processor/src/stackwalker/arm.rs
+++ b/minidump-processor/src/stackwalker/arm.rs
@@ -127,7 +127,7 @@ where
     // Unlike ARM64, we don't bother trying really hard to restore lr
     let last_lr = ctx.get_register(LINK_REGISTER, valid)?;
 
-    if last_fp as u64 >= u64::MAX - POINTER_WIDTH as u64 * 2 {
+    if last_fp as u32 >= u32::MAX - POINTER_WIDTH as u32 * 2 {
         // Although this code generally works fine if the pointer math overflows,
         // debug builds will still panic, and this guard protects against it without
         // drowning the rest of the code in checked_add.

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -850,3 +850,122 @@ fn test_cfi_reject_bad_exprs() {
     let s = f.walk_stack(stack);
     assert_eq!(s.frames.len(), 1);
 }
+
+#[test]
+fn test_frame_pointer_overflow() {
+    // Make sure we don't explode when trying frame pointer analysis on a value
+    // that will overflow.
+
+    type Pointer = u64;
+    let stack_max: Pointer = Pointer::MAX;
+    let stack_size: Pointer = 1000;
+    let bad_frame_ptr: Pointer = stack_max;
+
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    let stack_start: Pointer = stack_max - stack_size;
+    stack.start().set_const(stack_start as u64);
+
+    stack = stack
+        // frame 0
+        .append_repeated(0, stack_size as usize); // junk, not important to the test
+
+    f.raw.set_register("pc", 0x00007400c0000200);
+    f.raw.set_register("fp", bad_frame_ptr);
+    f.raw
+        .set_register("sp", stack.start().value().unwrap() as Pointer);
+    f.raw.set_register("lr", 0x00007500b0000110);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 1);
+
+    // As long as we don't panic, we're good!
+}
+
+#[test]
+fn test_frame_pointer_barely_no_overflow() {
+    // This is a simple frame pointer test but with the all the values pushed
+    // as close to the upper memory boundary as possible, to confirm that
+    // our code doesn't randomly overflow *AND* isn't overzealous in
+    // its overflow guards.
+
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+
+    type Pointer = u64;
+    let stack_max: Pointer = Pointer::MAX;
+    let pointer_size: Pointer = std::mem::size_of::<Pointer>() as Pointer;
+    let stack_size: Pointer = pointer_size * 3;
+
+    let stack_start: Pointer = stack_max - stack_size;
+    let return_address: Pointer = 0x00007500b0000110;
+    stack.start().set_const(stack_start as u64);
+
+    let frame0_fp = Label::new();
+    let frame1_sp = Label::new();
+    let frame1_fp = Label::new();
+
+    stack = stack
+        // frame 0
+        .mark(&frame0_fp)
+        .D64(&frame1_fp) // caller-pushed %rbp
+        .D64(return_address) // actual return address
+        // frame 1
+        .mark(&frame1_sp)
+        .mark(&frame1_fp) // end of stack
+        .D64(0);
+
+    f.raw.set_register("pc", 0x00007400c0000200);
+    f.raw
+        .set_register("fp", frame0_fp.value().unwrap() as Pointer);
+    f.raw
+        .set_register("sp", stack.start().value().unwrap() as Pointer);
+    f.raw.set_register("lr", return_address);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 2);
+
+    {
+        // Frame 0
+        let frame = &s.frames[0];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::Context);
+        assert_eq!(frame.context.valid, MinidumpContextValidity::All);
+
+        if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
+            assert_eq!(
+                ctx.get_register("fp", valid).unwrap(),
+                frame0_fp.value().unwrap() as Pointer
+            );
+        } else {
+            unreachable!();
+        }
+    }
+
+    {
+        // Frame 1
+        let frame = &s.frames[1];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::FramePointer);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 4);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame1_sp.value().unwrap() as Pointer
+            );
+            assert_eq!(
+                ctx.get_register("fp", valid).unwrap(),
+                frame1_fp.value().unwrap() as Pointer
+            );
+            assert_eq!(ctx.get_register("lr", valid).unwrap(), return_address);
+        } else {
+            unreachable!();
+        }
+    }
+}

--- a/minidump-processor/src/stackwalker/arm_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm_unittest.rs
@@ -739,3 +739,158 @@ fn test_cfi_reject_bad_exprs() {
     let s = f.walk_stack(stack);
     assert_eq!(s.frames.len(), 1);
 }
+
+#[test]
+fn test_frame_pointer_overflow() {
+    // Make sure we don't explode when trying frame pointer analysis on a value
+    // that will overflow.
+
+    type Pointer = u32;
+    let stack_max: Pointer = Pointer::MAX;
+    let stack_size: Pointer = 1000;
+    let bad_frame_ptr: Pointer = stack_max;
+
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    let stack_start: Pointer = stack_max - stack_size;
+    stack.start().set_const(stack_start as u64);
+
+    stack = stack
+        // frame 0
+        .append_repeated(0, stack_size as usize); // junk, not important to the test
+
+    f.raw.set_register("pc", 0x7a100000);
+    f.raw.set_register("fp", bad_frame_ptr);
+    f.raw
+        .set_register("sp", stack.start().value().unwrap() as Pointer);
+    f.raw.set_register("lr", 0x7b302000);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 1);
+
+    // As long as we don't panic, we're good!
+}
+
+#[test]
+fn test_frame_pointer_overflow_nonsense_32bit_stack() {
+    // same as test_frame_pointer_overflow, but we're going to abuse the fact
+    // that rust-minidump prefers representing things in 64-bit to create
+    // impossible stack addresses that overflow 32-bit integers but appear
+    // valid in 64-bit. By doing this memory reads will "succeed" but
+    // pointer math done in the native pointer width will overflow and
+    // everything will be sad.
+
+    type Pointer = u32;
+    let pointer_size: u64 = std::mem::size_of::<Pointer>() as u64;
+    let stack_max: u64 = Pointer::MAX as u64 + pointer_size * 2;
+    let stack_size: u64 = 1000;
+    let bad_frame_ptr: u64 = Pointer::MAX as u64 - pointer_size;
+
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    let stack_start: u64 = stack_max - stack_size;
+    stack.start().set_const(stack_start as u64);
+
+    stack = stack
+        // frame 0
+        .append_repeated(0, 1000); // junk, not important to the test
+
+    f.raw.set_register("pc", 0x7a100000);
+    f.raw.set_register("fp", bad_frame_ptr as u32);
+    f.raw
+        .set_register("sp", stack.start().value().unwrap() as Pointer);
+    f.raw.set_register("lr", 0x7b302000);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 1);
+
+    // As long as we don't panic, we're good!
+}
+
+#[test]
+fn test_frame_pointer_barely_no_overflow() {
+    // This is a simple frame pointer test but with the all the values pushed
+    // as close to the upper memory boundary as possible, to confirm that
+    // our code doesn't randomly overflow *AND* isn't overzealous in
+    // its overflow guards.
+
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+
+    type Pointer = u32;
+    let stack_max: Pointer = Pointer::MAX;
+    let pointer_size: Pointer = std::mem::size_of::<Pointer>() as Pointer;
+    let stack_size: Pointer = pointer_size * 3;
+
+    let stack_start: Pointer = stack_max - stack_size;
+    let return_address: Pointer = 0x7b302000;
+    stack.start().set_const(stack_start as u64);
+
+    let frame0_fp = Label::new();
+    let frame1_sp = Label::new();
+    let frame1_fp = Label::new();
+
+    stack = stack
+        // frame 0
+        .mark(&frame0_fp)
+        .D32(&frame1_fp) // caller-pushed %rbp
+        .D32(return_address) // actual return address
+        // frame 1
+        .mark(&frame1_sp)
+        .mark(&frame1_fp) // end of stack
+        .D32(0);
+
+    f.raw.set_register("pc", 0x7a100000);
+    f.raw
+        .set_register("fp", frame0_fp.value().unwrap() as Pointer);
+    f.raw
+        .set_register("sp", stack.start().value().unwrap() as Pointer);
+    f.raw.set_register("lr", return_address);
+
+    let s = f.walk_stack(stack);
+    assert_eq!(s.frames.len(), 2);
+
+    {
+        // Frame 0
+        let frame = &s.frames[0];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::Context);
+        assert_eq!(frame.context.valid, MinidumpContextValidity::All);
+
+        if let MinidumpRawContext::Arm(ctx) = &frame.context.raw {
+            assert_eq!(
+                ctx.get_register("fp", valid).unwrap(),
+                frame0_fp.value().unwrap() as Pointer
+            );
+        } else {
+            unreachable!();
+        }
+    }
+
+    {
+        // Frame 1
+        let frame = &s.frames[1];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::FramePointer);
+        if let MinidumpContextValidity::Some(ref which) = valid {
+            assert_eq!(which.len(), 4);
+        } else {
+            unreachable!();
+        }
+
+        if let MinidumpRawContext::Arm(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address);
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame1_sp.value().unwrap() as Pointer
+            );
+            assert_eq!(
+                ctx.get_register("fp", valid).unwrap(),
+                frame1_fp.value().unwrap() as Pointer
+            );
+            assert_eq!(ctx.get_register("lr", valid).unwrap(), return_address);
+        } else {
+            unreachable!();
+        }
+    }
+}

--- a/minidump-processor/src/stackwalker/x86.rs
+++ b/minidump-processor/src/stackwalker/x86.rs
@@ -154,7 +154,7 @@ where
     // %bp_new = *(%bp_old)
     // %sp_new = %bp_old + ptr*2
 
-    if last_bp as u64 >= u64::MAX - POINTER_WIDTH as u64 * 2 {
+    if last_bp as u32 >= u32::MAX - POINTER_WIDTH as u32 * 2 {
         // Although this code generally works fine if the pointer math overflows,
         // debug builds will still panic, and this guard protects against it without
         // drowning the rest of the code in checked_add.


### PR DESCRIPTION
Fixes #422

This issue is kinda nonsense, but in a 'hey good job fuzzer for finding this wild input' kinda way?
Basically rust-minidump likes doing things in 64-bit to reuse code and keep things uniform, but this
creates a fun situation where you can define *impossible* memory ranges for a 32-bit system and have
calculated pointers successfully access that memory because the operations are happening in 64-bit.

In-and-of-itself this is not a problem, but it does mean that things can go Bad when you have some
of the operations happening in the platform's native width, causing some operations to succeed and
others to overflow. In particular, this would allow you to load some memory that is beyond u32::MAX
(which normally would be a strong proof that the entire memory range is a valid pointer) and then
update the 32-bit frame pointer to that address, causing an overflow.

The fix is to simply do the overflow check that *already existed for exactly this code* in 32-bit
instead of 64-bit. I'm not sure if an actual minidump would have been able to trigger this bug,
since it's possible some earlier code would have freaked out at the memory range definitions.
But hey, the guards were wrong either way.