### PR TITLE
Return more correct code/debug identifiers for macOS minidumps

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -476,7 +476,7 @@ impl<'a> scroll::ctx::TryFromCtx<'a, Endian> for CV_INFO_PDB70 {
 /// assert_eq!("0000000A000B000C0102030405060708", format!("{:#}", guid));
 /// ```
 ///
-/// [msdn]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa373931(v=vs.85).aspx
+/// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/guiddef/ns-guiddef-guid
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Pread, SizeWith)]
 pub struct GUID {
     pub data1: u32,

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -32,24 +32,6 @@ fn locate_testdata() -> PathBuf {
     panic!("Couldn't find testdata directory! Tried: {:?}", paths);
 }
 
-fn read_macos_test_minidump() -> Result<Minidump<'static, memmap2::Mmap>, Error> {
-    let path = locate_testdata().join("macos-mini.dmp");
-    println!("minidump: {:?}", path);
-    Minidump::read_path(&path)
-}
-
-fn read_linux_test_minidump() -> Result<Minidump<'static, memmap2::Mmap>, Error> {
-    let path = locate_testdata().join("linux-mini.dmp");
-    println!("minidump: {:?}", path);
-    Minidump::read_path(&path)
-}
-
-fn read_windows_test_minidump() -> Result<Minidump<'static, memmap2::Mmap>, Error> {
-    let path = locate_testdata().join("windows-mini.dmp");
-    println!("minidump: {:?}", path);
-    Minidump::read_path(&path)
-}
-
 fn read_test_minidump() -> Result<Minidump<'static, memmap2::Mmap>, Error> {
     let path = locate_testdata().join("test.dmp");
     println!("minidump: {:?}", path);
@@ -60,107 +42,6 @@ fn testdata_symbol_path() -> PathBuf {
     let path = locate_testdata().join("symbols");
     println!("symbol path: {:?}", path);
     path
-}
-
-#[test]
-fn test_linux_minidump() {
-    let dump = read_linux_test_minidump().unwrap();
-    let state = minidump_processor::process_minidump(
-        &dump,
-        &Symbolizer::new(simple_symbol_supplier(vec![])),
-    )
-    .unwrap();
-    let mut module_list = state.modules.iter();
-
-    let module = module_list.next().unwrap();
-    assert_eq!(
-        module.debug_identifier().unwrap().into_owned(),
-        "C0BCC3F19827FE653058404B2831D9E60",
-        "debug identifier"
-    );
-    assert_eq!(
-        module.code_identifier().into_owned(),
-        "f1c3bcc0279865fe3058404b2831d9e64135386c",
-        "code identifier"
-    );
-
-    let module = module_list.next().unwrap();
-    assert_eq!(
-        module.debug_identifier().unwrap().into_owned(),
-        "E45DB8DFAF2D09FD640C8FE377D572DE0",
-        "debug identifier"
-    );
-    assert_eq!(
-        module.code_identifier().into_owned(),
-        "dfb85de42daffd09640c8fe377d572de3e168920",
-        "code identifier"
-    );
-}
-
-#[test]
-fn test_macos_minidump() {
-    let dump = read_macos_test_minidump().unwrap();
-    let state = minidump_processor::process_minidump(
-        &dump,
-        &Symbolizer::new(simple_symbol_supplier(vec![])),
-    )
-    .unwrap();
-    let mut module_list = state.modules.iter();
-
-    let module = module_list.next().unwrap();
-    assert_eq!(
-        module.debug_identifier().unwrap(),
-        "67E9247C814E392BA027DBDE6748FCBF0",
-        "debug identifier"
-    );
-    assert_eq!(
-        module.code_identifier(),
-        "67E9247C814E392BA027DBDE6748FCBF0",
-        "code identifier"
-    );
-
-    let module = module_list.next().unwrap();
-    assert_eq!(
-        module.debug_identifier().unwrap(),
-        "36385A3A60D332DBBF55C6D8931A7AA60",
-        "debug identifier"
-    );
-    assert_eq!(
-        module.code_identifier(),
-        "36385A3A60D332DBBF55C6D8931A7AA60",
-        "code identifier"
-    );
-}
-
-#[test]
-fn test_windows_minidump() {
-    let dump = read_windows_test_minidump().unwrap();
-    let state = minidump_processor::process_minidump(
-        &dump,
-        &Symbolizer::new(simple_symbol_supplier(vec![])),
-    )
-    .unwrap();
-    let mut module_list = state.modules.iter();
-
-    let module = module_list.next().unwrap();
-    assert_eq!(
-        module.debug_identifier().unwrap(),
-        "3249D99D0C4049318610F4E4FB0B69361",
-        "debug identifier"
-    );
-    assert_eq!(module.code_identifier(), "5AB380779000", "code identifier");
-
-    let module = module_list.next().unwrap();
-    assert_eq!(
-        module.debug_identifier().unwrap(),
-        "971F98E5CE6041FFB2D7235BBEB345781",
-        "debug identifier"
-    );
-    assert_eq!(
-        module.code_identifier(),
-        "59B0D8F3183000",
-        "code identifier"
-    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
This is related to the initiative outlined in https://github.com/getsentry/symbolicator/issues/620.

This PR fills in the currently incomplete implementation of `code_identifier` as well as a subsection of `debug_identifier` on macOS/Solaris(/maybe iOS, NaCl, PS3) minidump modules. The way this is done is by relying on the assumption that the `age` field on a module's CV record is only ever `0` if the minidump was created by Breakpad on a non-Windows device. See Breakpad's minidump writer for [macOS](https://github.com/google/breakpad/blob/main/src/client/mac/handler/minidump_generator.cc#L1468-L1486) and [Solaris](https://github.com/google/breakpad/blob/main/src/client/solaris/handler/minidump_generator.cc#L474-L488).

The reason why I'm depending on this rather fragile behaviour is because the correct way of going about this would [require access to the contents of a `MinidumpSystemInfo` in `code_identifier` and possibly `debug_identifier`](https://github.com/google/breakpad/blob/main/src/processor/minidump.cc#L1988-L1999). As far as I can tell, doing this the correct way would require much more invasive changes to the API, so I went with this hacky approach to get the ball rolling.

Some of the aforementioned invasive changes involve changing the `Module` trait in `minidump-common`, or adding an `Option<MinidumpSystemInfo>` field to a `MinidumpModule`. I've taken a look at `get_crash_reason` but it doesn't completely neatly map to the use case we have here. The way `MinidumpThread` works with stream dependencies looked like a good start, though - would appreciate thoughts on this.

Given that it's likely that a sizable amount of the diff here will be affected by https://github.com/luser/rust-minidump/pull/432, what I'd really love feedback on here is whether the approach here is going in the right direction or if I should re-think how to solve this problem.