### PR TITLE
Implement MinidumpMemory64List stream

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -91,6 +91,20 @@ pub struct MINIDUMP_MEMORY_DESCRIPTOR {
     pub memory: MINIDUMP_LOCATION_DESCRIPTOR,
 }
 
+/// A large range of memory contained within a minidump (usually a full dump)
+/// consisting of a base address and a size.
+///
+/// This struct matches the [Microsoft struct][msdn] of the same name.
+///
+/// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory_descriptor64
+#[derive(Debug, Copy, Clone, Default, Pread, SizeWith)]
+pub struct MINIDUMP_MEMORY_DESCRIPTOR64 {
+    /// The base address of this memory range from the process.
+    pub start_of_memory_range: u64,
+    /// The size of this data.
+    pub data_size: u64,
+}
+
 /// Information about a data stream contained in a minidump file.
 ///
 /// The minidump header contains a pointer to a list of these structs which allows locating
@@ -161,6 +175,15 @@ pub enum MINIDUMP_STREAM_TYPE {
     /// See [`MINIDUMP_SYSTEM_INFO`].
     SystemInfoStream = 7,
     ThreadExListStream = 8,
+    /// The list of large memory regions from the process contained within this dump
+    ///
+    /// See [`MINIDUMP_MEMORY_DESCRIPTOR64`].
+    ///
+    /// Microsoft declares a [`MINIDUMP_MEMORY64_LIST`][list] struct which is the actual format
+    /// of this stream, but it is a variable-length struct so no matching definition is provided
+    /// in this crate.
+    ///
+    /// [list]: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory64_list
     Memory64ListStream = 9,
     CommentStreamA = 10,
     CommentStreamW = 11,

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -523,6 +523,7 @@ where
     // Other streams depend on these, so load them upfront.
     let system_info = dump.get_stream::<MinidumpSystemInfo>().ok();
     let memory_list = dump.get_stream::<MinidumpMemoryList<'_>>().ok();
+    let memory64_list = dump.get_stream::<MinidumpMemory64List<'_>>().ok();
     let misc_info = dump.get_stream::<MinidumpMiscInfo>().ok();
 
     if let Ok(thread_list) = dump.get_stream::<MinidumpThreadList<'_>>() {
@@ -541,6 +542,9 @@ where
     }
     if let Some(memory_list) = memory_list {
         memory_list.print(output)?;
+    }
+    if let Some(memory64_list) = memory64_list {
+        memory64_list.print(output)?;
     }
     if let Ok(memory_info_list) = dump.get_stream::<MinidumpMemoryInfoList<'_>>() {
         memory_info_list.print(output)?;

--- a/minidump/fuzz/fuzz_targets/parse.rs
+++ b/minidump/fuzz/fuzz_targets/parse.rs
@@ -4,9 +4,9 @@ use libfuzzer_sys::fuzz_target;
 use minidump::{
     MinidumpAssertion, MinidumpBreakpadInfo, MinidumpCrashpadInfo, MinidumpException,
     MinidumpLinuxCpuInfo, MinidumpLinuxEnviron, MinidumpLinuxLsbRelease, MinidumpLinuxMaps,
-    MinidumpLinuxProcStatus, MinidumpMacCrashInfo, MinidumpMemoryInfoList, MinidumpMemoryList,
-    MinidumpMiscInfo, MinidumpModuleList, MinidumpSystemInfo, MinidumpThreadList,
-    MinidumpThreadNames, MinidumpUnloadedModuleList,
+    MinidumpLinuxProcStatus, MinidumpMacCrashInfo, MinidumpMemory64List, MinidumpMemoryInfoList,
+    MinidumpMemoryList, MinidumpMiscInfo, MinidumpModuleList, MinidumpSystemInfo,
+    MinidumpThreadList, MinidumpThreadNames, MinidumpUnloadedModuleList,
 };
 
 fuzz_target!(|data: &[u8]| {
@@ -21,6 +21,7 @@ fuzz_target!(|data: &[u8]| {
         let _ = dump.get_stream::<MinidumpLinuxMaps>();
         let _ = dump.get_stream::<MinidumpLinuxProcStatus>();
         let _ = dump.get_stream::<MinidumpMacCrashInfo>();
+        let _ = dump.get_stream::<MinidumpMemory64List>();
         let _ = dump.get_stream::<MinidumpMemoryInfoList>();
         let _ = dump.get_stream::<MinidumpMemoryList>();
         let _ = dump.get_stream::<MinidumpMiscInfo>();

--- a/minidump/src/lib.rs
+++ b/minidump/src/lib.rs
@@ -322,6 +322,9 @@
 //! * `MINIDUMP_THREAD_EX_LIST` (yes, the stream with "EX_LIST" in the name isn't an
 //!   EX list, names are hard.)
 //!
+//! The stream [`MinidumpMemory64List`] is a variant of list stream. It starts with
+//! a `u64` count of entries, a 64-bit shared RVA for all entries, then followed by
+//! an array of entires [`MINIDUMP_MEMORY_DESCRIPTOR64`][format::MINIDUMP_MEMORY_DESCRIPTOR64].
 //!
 //!
 //! ### EX List Streams

--- a/minidump/tests/test_minidump.rs
+++ b/minidump/tests/test_minidump.rs
@@ -351,3 +351,21 @@ fn test_linux_os_version() {
         "#1 SMP Mon Nov 6 16:00:12 UTC 2017",
     );
 }
+
+#[test]
+fn test_full_dump_memory() {
+    let path = get_test_minidump_path("full-dump.dmp");
+    let dump = Minidump::read_path(&path).unwrap();
+    let memory_list = dump.get_stream::<MinidumpMemory64List<'_>>().unwrap();
+    assert_eq!(memory_list.iter().count(), 54);
+    let blocks: Vec<_> = memory_list.iter().take(3).collect();
+    assert_eq!(blocks[0].base_address, 0x007FFE0000);
+    assert_eq!(blocks[0].size, 0x1000);
+    assert_eq!(blocks[0].bytes[0..8], [0, 0, 0, 0, 0, 0, 0xA0, 0x0F]);
+    assert_eq!(blocks[1].base_address, 0x007FFE9000);
+    assert_eq!(blocks[1].size, 0x1000);
+    assert_eq!(blocks[1].bytes[0..8], [0x48, 0x61, 0x6C, 0x54, 0, 0, 0, 0]);
+    assert_eq!(blocks[2].base_address, 0x9897D0D000);
+    assert_eq!(blocks[2].size, 0x3000);
+    assert_eq!(blocks[2].bytes[0..8], [0, 0, 0, 0, 0, 0, 0, 0]);
+}


### PR DESCRIPTION
I happened to need to read a full dump and found this missing in the library, so I implemented it.

To reuse the existing code, I abstracted some functions on `MinidumpMemoryList` into a generic type `MinidumpMemoryListGeneric`, and made both `MinidumpMemoryList` and the new `MinidumpMemory64List` type aliases of the generic type.