### PR TITLE
Stack scanning: decrement address before lookup

### DIFF
--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -230,6 +230,13 @@ async fn instruction_seems_valid_by_symbols<P>(
 where
     P: SymbolProvider + Sync,
 {
+    // We want to validate the address of the call instruction, not the return address. Usually the
+    // return address is one after the call, so we subtract 1 here.
+    //
+    // See the corresponding commit in Breakpad:
+    // https://github.com/google/breakpad/commit/087795c851d269a49baf6cd0fb886c2990729f44
+    let instruction = instruction - 1;
+
     if let Some(module) = modules.module_at_address(instruction as u64) {
         // Create a dummy frame symbolizing implementation to feed into
         // our symbol provider with the address we're interested in. If

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -233,7 +233,7 @@ where
     // Our input is a candidate return address, but we *really* want to validate the address
     // of the call instruction *before* the return address. In theory this symbol-based
     // analysis shouldn't *care* whether we're looking at the call or the instruction
-    // after it, but there is one corner case where the return address can be invalid 
+    // after it, but there is one corner case where the return address can be invalid
     // but the instruction before it isn't: noreturn.
     //
     // If the *callee* is noreturn, then the caller has no obligation to have any instructions

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -235,7 +235,12 @@ where
     //
     // See the corresponding commit in Breakpad:
     // https://github.com/google/breakpad/commit/087795c851d269a49baf6cd0fb886c2990729f44
-    let instruction = instruction - 1;
+    let instruction = instruction.saturating_sub(1);
+
+    // NULL pointer is definitely not valid
+    if instruction == 0 {
+        return false;
+    }
 
     if let Some(module) = modules.module_at_address(instruction as u64) {
         // Create a dummy frame symbolizing implementation to feed into


### PR DESCRIPTION
When stack scanning, we want to validate the address _before_ the return address, which is usually the address of the function call. Breakpad uses this heuristic, see https://github.com/google/breakpad/commit/087795c851d269a49baf6cd0fb886c2990729f44.

We have a test case where `rust-minidump` stack scanning returns a clearly incorrect frame with a suspiciously aligned address, see this github check: https://github.com/getsentry/symbolicator/runs/5144569674?check_suite_focus=true#step:5:3147. This PR would fix this case.