### PR TITLE
Fix PDB 2.0 DebugId format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "debugid"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91cf5a8c2f2097e2a32627123508635d47ce10563d999ec1a95addf08b502ba"
+checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
 dependencies = [
  "uuid",
 ]

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "luser/rust-minidump" }
 [dependencies]
 async-trait = "0.1.51"
 circular = "0.3.0"
-debugid = "0.7"
+debugid = "0.7.3"
 log = "0.4.1"
 minidump-common = { version = "0.9.6", path = "../minidump-common" }
 nom = "~1.2.2"

--- a/minidump-common/Cargo.toml
+++ b/minidump-common/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "luser/rust-minidump" }
 [dependencies]
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 bitflags = "1.3.2"
-debugid = "0.7"
+debugid = "0.7.3"
 enum-primitive-derive = "0.2.2"
 log = "0.4.1"
 num-traits = "0.2"

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -23,7 +23,7 @@ symbolic-syms = []
 async-trait = "0.1.51"
 breakpad-symbols = { version = "0.9.6", path = "../breakpad-symbols", optional = true }
 clap = "2.34"
-debugid = "0.7"
+debugid = "0.7.3"
 log = "0.4"
 memmap2 = "0.5.2"
 minidump = { version = "0.9.6", path = "../minidump" }

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 arbitrary = { version = "1", optional = true, features = ["derive"] }
-debugid = "0.7"
+debugid = "0.7.3"
 encoding = "0.2"
 log = "0.4.1"
 memmap2 = "0.5.2"

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -942,10 +942,7 @@ impl Module for MinidumpModule {
                 .ok()?;
                 Some(DebugId::from_parts(uuid, raw.age))
             }
-            Some(CodeView::Pdb20(ref raw)) => {
-                let uuid = Uuid::from_fields(raw.signature, 0, 0, &[0, 0, 0, 0]).ok()?;
-                Some(DebugId::from_parts(uuid, raw.age))
-            }
+            Some(CodeView::Pdb20(ref raw)) => Some(DebugId::from_pdb20(raw.signature, raw.age)),
             Some(CodeView::Elf(ref raw)) => {
                 // For backwards-compat (Linux minidumps have historically
                 // been written using PDB70 CodeView info), treat build_id

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -4850,6 +4850,48 @@ mod test {
     }
 
     #[test]
+    fn test_module_list_pdb20() {
+        let name = DumpString::new("single module", Endian::Little);
+        let cv_record = Section::with_endian(Endian::Little)
+            .D32(md::CvSignature::Pdb20 as u32) // cv_signature
+            .D32(0x0) // cv_offset
+            .D32(0xabcd1234) // signature
+            .D32(1) // age
+            .append_bytes(b"c:\\foo\\file.pdb\0"); // pdb_file_name
+        let module = SynthModule::new(
+            Endian::Little,
+            0xa90206ca83eb2852,
+            0xada542bd,
+            &name,
+            0xb1054d2a,
+            0x34571371,
+            Some(&STOCK_VERSION_INFO),
+        )
+        .cv_record(&cv_record);
+        let dump = SynthMinidump::with_endian(Endian::Little)
+            .add_module(module)
+            .add(name)
+            .add(cv_record);
+        let dump = read_synth_dump(dump).unwrap();
+        let module_list = dump.get_stream::<MinidumpModuleList>().unwrap();
+        let modules = module_list.iter().collect::<Vec<_>>();
+        assert_eq!(modules.len(), 1);
+        assert_eq!(modules[0].base_address(), 0xa90206ca83eb2852);
+        assert_eq!(modules[0].size(), 0xada542bd);
+        assert_eq!(modules[0].code_file(), "single module");
+        // time_date_stamp and size_of_image concatenated
+        assert_eq!(
+            modules[0].code_identifier(),
+            CodeId::new("B1054D2Aada542bd".to_string())
+        );
+        assert_eq!(modules[0].debug_file().unwrap(), "c:\\foo\\file.pdb");
+        assert_eq!(
+            modules[0].debug_identifier().unwrap(),
+            DebugId::from_pdb20(0xabcd1234, 1)
+        );
+    }
+
+    #[test]
     fn test_unloaded_module_list() {
         let name = DumpString::new("single module", Endian::Little);
         let module = SynthUnloadedModule::new(


### PR DESCRIPTION
The previous implementation did not correctly represent the DebugId of
(very old) PDB 2.0 PE files.  The new debugid release suppots these
correctly.