### PR TITLE
MinidumpModule: Don't return DebugId for invalid build_id

### DIFF
--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -964,6 +964,12 @@ impl Module for MinidumpModule {
                 Some(DebugId::from_parts(uuid, raw.age))
             }
             Some(CodeView::Elf(ref raw)) => {
+                // For empty or trivial `build_id`s, we don't want to return a `DebugId`.
+                // This can happen for mapped files that aren't executable, like fonts or .jar files.
+                if raw.build_id.iter().all(|byte| *byte == 0) {
+                    return None;
+                }
+
                 // For backwards-compat (Linux minidumps have historically
                 // been written using PDB70 CodeView info), treat build_id
                 // as if the first 16 bytes were a GUID.


### PR DESCRIPTION
The minidump processor currently returns modules with debug ids of `Some(00000000-0000-0000-0000-000000000000)`. This fixes that case by checking that the `build_id` is not just a list of zeros.