### PR TITLE
ref: Pass SystemInfo through to Unwind impls

### DIFF
--- a/minidump-processor/fuzz/fuzz_targets/walk_stack.rs
+++ b/minidump-processor/fuzz/fuzz_targets/walk_stack.rs
@@ -3,8 +3,9 @@ use libfuzzer_sys::fuzz_target;
 
 use minidump::{MinidumpContext, MinidumpContextValidity, MinidumpMemory};
 use minidump::{MinidumpModule, MinidumpModuleList};
+use minidump::system_info::{Cpu, Os};
 use minidump_processor::walk_stack;
-use minidump_processor::{string_symbol_supplier, CallStack, Symbolizer};
+use minidump_processor::{string_symbol_supplier, CallStack, Symbolizer, SystemInfo};
 use std::collections::HashMap;
 use test_assembler::Section;
 
@@ -43,6 +44,15 @@ impl TestFixture {
             size,
             bytes: &stack,
         };
+        let system_info = SystemInfo {
+            os: Os::Windows,
+            os_version: None,
+            os_build: None,
+            cpu: Cpu::X86_64,
+            cpu_info: None,
+            cpu_microcode_version: None,
+            cpu_count: 1,
+        };
 
         let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
 
@@ -51,6 +61,7 @@ impl TestFixture {
                 &Some(&context),
                 Some(&stack_memory),
                 &self.modules,
+                &system_info,
                 &symbolizer,
             )
             .await,

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -370,9 +370,14 @@ where
 
         let stack_memory = thread.stack_memory(&memory_list);
 
-        let mut stack =
-            stackwalker::walk_stack(&context, stack_memory.as_deref(), &modules, symbol_provider)
-                .await;
+        let mut stack = stackwalker::walk_stack(
+            &context,
+            stack_memory.as_deref(),
+            &modules,
+            &system_info,
+            symbol_provider,
+        )
+        .await;
         stack.thread_id = id;
         for frame in &mut stack.frames {
             // If the frame doesn't have a loaded module, try to find an unloaded module

--- a/minidump-processor/src/stackwalker/amd64.rs
+++ b/minidump-processor/src/stackwalker/amd64.rs
@@ -9,7 +9,7 @@
 use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
 use crate::stackwalker::CfiStackWalker;
-use crate::SymbolProvider;
+use crate::{SymbolProvider, SystemInfo};
 use log::trace;
 use minidump::format::CONTEXT_AMD64;
 use minidump::{
@@ -416,6 +416,7 @@ impl Unwind for CONTEXT_AMD64 {
         grand_callee: Option<&StackFrame>,
         stack_memory: Option<&MinidumpMemory<'_>>,
         modules: &MinidumpModuleList,
+        _system_info: &SystemInfo,
         syms: &P,
     ) -> Option<StackFrame>
     where

--- a/minidump-processor/src/stackwalker/amd64_unittest.rs
+++ b/minidump-processor/src/stackwalker/amd64_unittest.rs
@@ -3,8 +3,9 @@
 
 use crate::process_state::*;
 use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer};
+use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
 use minidump::format::CONTEXT_AMD64;
+use minidump::system_info::{Cpu, Os};
 use minidump::*;
 use std::collections::HashMap;
 use test_assembler::*;
@@ -43,11 +44,21 @@ impl TestFixture {
             size,
             bytes: &stack,
         };
+        let system_info = SystemInfo {
+            os: Os::Windows,
+            os_version: None,
+            os_build: None,
+            cpu: Cpu::X86_64,
+            cpu_info: None,
+            cpu_microcode_version: None,
+            cpu_count: 1,
+        };
         let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
         walk_stack(
             &Some(&context),
             Some(&stack_memory),
             &self.modules,
+            &system_info,
             &symbolizer,
         )
         .await

--- a/minidump-processor/src/stackwalker/arm.rs
+++ b/minidump-processor/src/stackwalker/arm.rs
@@ -7,7 +7,7 @@
 use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
 use crate::stackwalker::CfiStackWalker;
-use crate::SymbolProvider;
+use crate::{SymbolProvider, SystemInfo};
 use log::trace;
 use minidump::{
     CpuContext, MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
@@ -305,6 +305,7 @@ impl Unwind for ArmContext {
         grand_callee: Option<&StackFrame>,
         stack_memory: Option<&MinidumpMemory<'_>>,
         modules: &MinidumpModuleList,
+        _system_info: &SystemInfo,
         syms: &P,
     ) -> Option<StackFrame>
     where

--- a/minidump-processor/src/stackwalker/arm64.rs
+++ b/minidump-processor/src/stackwalker/arm64.rs
@@ -7,7 +7,7 @@
 use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
 use crate::stackwalker::CfiStackWalker;
-use crate::SymbolProvider;
+use crate::{SymbolProvider, SystemInfo};
 use log::trace;
 use minidump::{
     CpuContext, MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
@@ -425,6 +425,7 @@ impl Unwind for ArmContext {
         grand_callee: Option<&StackFrame>,
         stack_memory: Option<&MinidumpMemory<'_>>,
         modules: &MinidumpModuleList,
+        _system_info: &SystemInfo,
         syms: &P,
     ) -> Option<StackFrame>
     where

--- a/minidump-processor/src/stackwalker/arm64_old.rs
+++ b/minidump-processor/src/stackwalker/arm64_old.rs
@@ -7,7 +7,7 @@
 use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
 use crate::stackwalker::CfiStackWalker;
-use crate::SymbolProvider;
+use crate::{SymbolProvider, SystemInfo};
 use log::trace;
 use minidump::{
     CpuContext, MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
@@ -422,6 +422,7 @@ impl Unwind for ArmContext {
         grand_callee: Option<&StackFrame>,
         stack_memory: Option<&MinidumpMemory<'_>>,
         modules: &MinidumpModuleList,
+        _system_info: &SystemInfo,
         syms: &P,
     ) -> Option<StackFrame>
     where

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -6,7 +6,8 @@
 
 use crate::process_state::*;
 use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer};
+use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
+use minidump::system_info::{Cpu, Os};
 use minidump::*;
 use std::collections::HashMap;
 use test_assembler::*;
@@ -47,11 +48,21 @@ impl TestFixture {
             size,
             bytes: &stack,
         };
+        let system_info = SystemInfo {
+            os: Os::Windows,
+            os_version: None,
+            os_build: None,
+            cpu: Cpu::Arm64,
+            cpu_info: None,
+            cpu_microcode_version: None,
+            cpu_count: 1,
+        };
         let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
         walk_stack(
             &Some(&context),
             Some(&stack_memory),
             &self.modules,
+            &system_info,
             &symbolizer,
         )
         .await

--- a/minidump-processor/src/stackwalker/arm_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm_unittest.rs
@@ -3,8 +3,9 @@
 
 use crate::process_state::*;
 use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer};
+use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
 use minidump::format::CONTEXT_ARM;
+use minidump::system_info::{Cpu, Os};
 use minidump::*;
 use std::collections::HashMap;
 use test_assembler::*;
@@ -43,11 +44,21 @@ impl TestFixture {
             size,
             bytes: &stack,
         };
+        let system_info = SystemInfo {
+            os: Os::Windows,
+            os_version: None,
+            os_build: None,
+            cpu: Cpu::Arm,
+            cpu_info: None,
+            cpu_microcode_version: None,
+            cpu_count: 1,
+        };
         let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
         walk_stack(
             &Some(&context),
             Some(&stack_memory),
             &self.modules,
+            &system_info,
             &symbolizer,
         )
         .await

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -11,7 +11,7 @@ mod unwind;
 mod x86;
 
 use crate::process_state::*;
-use crate::{FrameWalker, SymbolProvider};
+use crate::{FrameWalker, SymbolProvider, SystemInfo};
 use log::trace;
 use minidump::*;
 use scroll::ctx::{SizeWith, TryFromCtx};
@@ -85,6 +85,7 @@ async fn get_caller_frame<P>(
     grand_callee_frame: Option<&StackFrame>,
     stack_memory: Option<&MinidumpMemory<'_>>,
     modules: &MinidumpModuleList,
+    system_info: &SystemInfo,
     symbol_provider: &P,
 ) -> Option<StackFrame>
 where
@@ -103,6 +104,7 @@ where
                 grand_callee_frame,
                 stack_memory,
                 modules,
+                system_info,
                 symbol_provider,
             )
             .await
@@ -113,6 +115,7 @@ where
                 grand_callee_frame,
                 stack_memory,
                 modules,
+                system_info,
                 symbol_provider,
             )
             .await
@@ -123,6 +126,7 @@ where
                 grand_callee_frame,
                 stack_memory,
                 modules,
+                system_info,
                 symbol_provider,
             )
             .await
@@ -133,6 +137,7 @@ where
                 grand_callee_frame,
                 stack_memory,
                 modules,
+                system_info,
                 symbol_provider,
             )
             .await
@@ -143,6 +148,7 @@ where
                 grand_callee_frame,
                 stack_memory,
                 modules,
+                system_info,
                 symbol_provider,
             )
             .await
@@ -173,6 +179,7 @@ pub async fn walk_stack<P>(
     maybe_context: &Option<&MinidumpContext>,
     stack_memory: Option<&MinidumpMemory<'_>>,
     modules: &MinidumpModuleList,
+    system_info: &SystemInfo,
     symbol_provider: &P,
 ) -> CallStack
 where
@@ -203,6 +210,7 @@ where
                 grand_callee_frame,
                 stack_memory,
                 modules,
+                system_info,
                 symbol_provider,
             )
             .await;

--- a/minidump-processor/src/stackwalker/unwind.rs
+++ b/minidump-processor/src/stackwalker/unwind.rs
@@ -2,7 +2,7 @@
 // file at the top-level directory of this distribution.
 
 use crate::process_state::StackFrame;
-use crate::SymbolProvider;
+use crate::{SymbolProvider, SystemInfo};
 use minidump::{MinidumpMemory, MinidumpModuleList};
 
 /// A trait for things that can unwind to a caller.
@@ -15,6 +15,7 @@ pub trait Unwind {
         grand_callee: Option<&StackFrame>,
         stack_memory: Option<&MinidumpMemory<'_>>,
         modules: &MinidumpModuleList,
+        system_info: &SystemInfo,
         symbol_provider: &P,
     ) -> Option<StackFrame>
     where

--- a/minidump-processor/src/stackwalker/x86.rs
+++ b/minidump-processor/src/stackwalker/x86.rs
@@ -9,7 +9,7 @@
 use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
 use crate::stackwalker::CfiStackWalker;
-use crate::SymbolProvider;
+use crate::{SymbolProvider, SystemInfo};
 use log::trace;
 use minidump::format::CONTEXT_X86;
 use minidump::{
@@ -392,6 +392,7 @@ impl Unwind for CONTEXT_X86 {
         grand_callee: Option<&StackFrame>,
         stack_memory: Option<&MinidumpMemory<'_>>,
         modules: &MinidumpModuleList,
+        _system_info: &SystemInfo,
         syms: &P,
     ) -> Option<StackFrame>
     where

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -3,8 +3,9 @@
 
 use crate::process_state::*;
 use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer};
+use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
 use minidump::format::CONTEXT_X86;
+use minidump::system_info::{Cpu, Os};
 use minidump::*;
 use std::collections::HashMap;
 use test_assembler::*;
@@ -43,11 +44,21 @@ impl TestFixture {
             size,
             bytes: &stack,
         };
+        let system_info = SystemInfo {
+            os: Os::Windows,
+            os_version: None,
+            os_build: None,
+            cpu: Cpu::X86,
+            cpu_info: None,
+            cpu_microcode_version: None,
+            cpu_count: 1,
+        };
         let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
         walk_stack(
             &Some(&context),
             Some(&stack_memory),
             &self.modules,
+            &system_info,
             &symbolizer,
         )
         .await


### PR DESCRIPTION
Using this, the Unwind implementations can apply heuristics
based on the platform-specific calling conventions.