### PR TITLE
FrameWalker: Add has_grand_callee method

### DIFF
--- a/breakpad-symbols/fuzz/fuzz_targets/cfi_eval.rs
+++ b/breakpad-symbols/fuzz/fuzz_targets/cfi_eval.rs
@@ -18,6 +18,7 @@ static STATIC_REGS: [&str; 14] = [
 
 struct TestFrameWalker<Reg> {
     instruction: Reg,
+    has_grand_callee: bool,
     grand_callee_param_size: u32,
     callee_regs: HashMap<&'static str, Reg>,
     caller_regs: HashMap<&'static str, Reg>,
@@ -62,6 +63,9 @@ impl Int for u64 {
 impl<Reg: Int + Copy> FrameWalker for TestFrameWalker<Reg> {
     fn get_instruction(&self) -> u64 {
         self.instruction.into_u64()
+    }
+    fn has_grand_callee(&self) -> bool {
+        self.has_grand_callee
     }
     fn get_grand_callee_parameter_size(&self) -> u32 {
         self.grand_callee_param_size
@@ -108,6 +112,7 @@ impl<Reg: Int + Copy> TestFrameWalker<Reg> {
 
             // Arbitrary values
             instruction: Reg::from_u64(0xF1CEFA32),
+            has_grand_callee: true,
             grand_callee_param_size: 4,
         }
     }

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -541,6 +541,8 @@ pub trait FrameSymbolizer {
 pub trait FrameWalker {
     /// Get the instruction address that we're trying to unwind from.
     fn get_instruction(&self) -> u64;
+    /// Check whether the callee has a callee of its own.
+    fn has_grand_callee(&self) -> bool;
     /// Get the number of bytes the callee's callee's parameters take up
     /// on the stack (or 0 if unknown/invalid). This is needed for
     /// STACK WIN unwinding.

--- a/breakpad-symbols/src/sym_file/walker.rs
+++ b/breakpad-symbols/src/sym_file/walker.rs
@@ -1044,6 +1044,7 @@ mod test {
 
     struct TestFrameWalker<Reg> {
         instruction: Reg,
+        has_grand_callee: bool,
         grand_callee_param_size: u32,
         callee_regs: HashMap<&'static str, Reg>,
         caller_regs: HashMap<&'static str, Reg>,
@@ -1088,6 +1089,9 @@ mod test {
     impl<Reg: Int + Copy> FrameWalker for TestFrameWalker<Reg> {
         fn get_instruction(&self) -> u64 {
             self.instruction.into_u64()
+        }
+        fn has_grand_callee(&self) -> bool {
+            self.has_grand_callee
         }
         fn get_grand_callee_parameter_size(&self) -> u32 {
             self.grand_callee_param_size
@@ -1134,6 +1138,7 @@ mod test {
 
                 // Arbitrary values
                 instruction: Reg::from_u64(0xF1CEFA32),
+                has_grand_callee: true,
                 grand_callee_param_size: 4,
             }
         }

--- a/minidump-processor/src/stackwalker/amd64.rs
+++ b/minidump-processor/src/stackwalker/amd64.rs
@@ -50,9 +50,11 @@ where
     let module = modules.module_at_address(callee.instruction)?;
 
     let grand_callee_parameter_size = grand_callee.and_then(|f| f.parameter_size).unwrap_or(0);
+    let has_grand_callee = grand_callee.is_some();
 
     let mut stack_walker = CfiStackWalker {
         instruction: callee.instruction,
+        has_grand_callee,
         grand_callee_parameter_size,
 
         callee_ctx: ctx,

--- a/minidump-processor/src/stackwalker/arm.rs
+++ b/minidump-processor/src/stackwalker/arm.rs
@@ -43,9 +43,11 @@ where
     let _last_sp = ctx.get_register(STACK_POINTER, valid)?;
     let module = modules.module_at_address(callee.instruction)?;
     let grand_callee_parameter_size = grand_callee.and_then(|f| f.parameter_size).unwrap_or(0);
+    let has_grand_callee = grand_callee.is_some();
 
     let mut stack_walker = CfiStackWalker {
         instruction: callee.instruction,
+        has_grand_callee,
         grand_callee_parameter_size,
 
         callee_ctx: ctx,

--- a/minidump-processor/src/stackwalker/arm64.rs
+++ b/minidump-processor/src/stackwalker/arm64.rs
@@ -45,9 +45,11 @@ where
     let _last_sp = ctx.get_register(STACK_POINTER, valid)?;
     let module = modules.module_at_address(callee.instruction)?;
     let grand_callee_parameter_size = grand_callee.and_then(|f| f.parameter_size).unwrap_or(0);
+    let has_grand_callee = grand_callee.is_some();
 
     let mut stack_walker = CfiStackWalker {
         instruction: callee.instruction,
+        has_grand_callee,
         grand_callee_parameter_size,
 
         callee_ctx: ctx,

--- a/minidump-processor/src/stackwalker/arm64_old.rs
+++ b/minidump-processor/src/stackwalker/arm64_old.rs
@@ -45,9 +45,11 @@ where
     let _last_sp = ctx.get_register(STACK_POINTER, valid)?;
     let module = modules.module_at_address(callee.instruction)?;
     let grand_callee_parameter_size = grand_callee.and_then(|f| f.parameter_size).unwrap_or(0);
+    let has_grand_callee = grand_callee.is_some();
 
     let mut stack_walker = CfiStackWalker {
         instruction: callee.instruction,
+        has_grand_callee,
         grand_callee_parameter_size,
 
         callee_ctx: ctx,

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -22,6 +22,7 @@ use std::convert::TryFrom;
 
 struct CfiStackWalker<'a, C: CpuContext> {
     instruction: u64,
+    has_grand_callee: bool,
     grand_callee_parameter_size: u32,
 
     callee_ctx: &'a C,
@@ -42,6 +43,9 @@ where
 {
     fn get_instruction(&self) -> u64 {
         self.instruction
+    }
+    fn has_grand_callee(&self) -> bool {
+        self.has_grand_callee
     }
     fn get_grand_callee_parameter_size(&self) -> u32 {
         self.grand_callee_parameter_size

--- a/minidump-processor/src/stackwalker/x86.rs
+++ b/minidump-processor/src/stackwalker/x86.rs
@@ -48,9 +48,11 @@ where
     let module = modules.module_at_address(callee.instruction)?;
 
     let grand_callee_parameter_size = grand_callee.and_then(|f| f.parameter_size).unwrap_or(0);
+    let has_grand_callee = grand_callee.is_some();
 
     let mut stack_walker = CfiStackWalker {
         instruction: callee.instruction,
+        has_grand_callee,
         grand_callee_parameter_size,
 
         callee_ctx: ctx,


### PR DESCRIPTION
This method is used as a proxy for whether the callee is the context frame. See https://github.com/luser/rust-minidump/pull/490.