### PR TITLE
Properly define error names instead of sloppily leaning on debug formatting

### DIFF
--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -156,6 +156,19 @@ pub enum ProcessError {
     MissingThreadList,
 }
 
+impl ProcessError {
+    /// Returns just the name of the error, as a more human-friendly version of
+    /// an error-code for error logging.
+    pub fn name(&self) -> &'static str {
+        match self {
+            ProcessError::MinidumpReadError(_) => "MinidumpReadError",
+            ProcessError::UnknownError => "UnknownError",
+            ProcessError::MissingSystemInfo => "MissingSystemInfo",
+            ProcessError::MissingThreadList => "MissingThreadList",
+        }
+    }
+}
+
 /// Unwind all threads in `dump` and return a report as a `ProcessState`.
 ///
 /// This is equivalent to [`process_minidump_with_options`] with

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -513,13 +513,13 @@ async fn main() {
                     }
                 }
                 Err(err) => {
-                    error!("{:?} - Error processing dump: {}", err, err);
+                    error!("{} - Error processing dump: {}", err.name(), err);
                     std::process::exit(1);
                 }
             }
         }
         Err(err) => {
-            error!("{:?} - Error reading dump: {}", err, err);
+            error!("{} - Error reading dump: {}", err.name(), err);
             std::process::exit(1);
         }
     }

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -100,6 +100,28 @@ pub enum Error {
     CodeViewReadFailure,
 }
 
+impl Error {
+    /// Returns just the name of the error, as a more human-friendly version of
+    /// an error-code for error logging.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Error::FileNotFound => "FileNotFound",
+            Error::IoError => "IoError",
+            Error::MissingHeader => "MissingHeader",
+            Error::HeaderMismatch => "HeaderMismatch",
+            Error::VersionMismatch => "VersionMismatch",
+            Error::MissingDirectory => "MissingDirectory",
+            Error::StreamReadFailure => "StreamReadFailure",
+            Error::StreamSizeMismatch { .. } => "StreamSizeMismatch",
+            Error::StreamNotFound => "StreamNotFound",
+            Error::ModuleReadFailure => "ModuleReadFailure",
+            Error::MemoryReadFailure => "MemoryReadFailure",
+            Error::DataError => "DataError",
+            Error::CodeViewReadFailure => "CodeViewReadFailure",
+        }
+    }
+}
+
 /// The fundamental unit of data in a `Minidump`.
 pub trait MinidumpStream<'a>: Sized {
     /// The stream type constant used in the `md::MDRawDirectory` entry.


### PR DESCRIPTION
This is the last blocker for *finally* cutting a release.