### PR TITLE
MinidumpModule: use system info for OS detection.

### DIFF
--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -962,13 +962,9 @@ impl Module for MinidumpModule {
         match self.codeview_info {
             Some(CodeView::Pdb70(ref raw)) => {
                 if self.os == Os::MacOs {
-                    // This is a macOS minidump. It looks like the age is
-                    // typically >0 for Windows minidumps, and Breakpad sets it
-                    // to 0 on macOS. We're relying on this observation in order
-                    // to distinguish between these two platforms since macOS
-                    // uses PDB70 instead of its own dedicated format.
-                    // See the following linked comment in a Windows PDB writer:
-                    // https://github.com/microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/PDB/dbi/pdb.cpp#L602-L606
+                    // MacOs uses PDB70 instead of its own dedicated format.
+                    // See the following issue for a potential MacOs-specific format:
+                    // https://github.com/luser/rust-minidump/issues/455
                     Some(CodeId::new(format!("{:#}", raw.signature)))
                 } else {
                     Some(CodeId::new(format!(


### PR DESCRIPTION
This adds an `os: Os` field to `MinidumpModule` that can be used for e.g. `code_identifier`.

Builds on https://github.com/luser/rust-minidump/pull/497. Fixes https://github.com/luser/rust-minidump/issues/474.

The `test_macos_ids()` test fails despite my changes—I think I'm setting the OS to MacOs correctly, but `Minidump::read` somehow interprets it as `Unknown`.